### PR TITLE
16 친구 추가 화면 구현

### DIFF
--- a/Moda/Feature/Friend/Add/FriendAddView.swift
+++ b/Moda/Feature/Friend/Add/FriendAddView.swift
@@ -21,11 +21,14 @@ private struct FriendAddState {
 
     // 선택된 셀(선택 시 목록 숨기고 카드만 노출)
     var selectedItem: FriendSearchItem?
+
+    // 선택된 항목의 "친구 여부"(추후 네트워크로 설정, 초기 nil이면 '친구 추가'로 노출)
+    var selectedIsFriend: Bool?
 }
 
 //MARK: 검색 결과 모델(목 데이터용 간단 모델 추후 수정필요)
 private struct FriendSearchItem: Identifiable, Hashable {
-    let id: String      // 사용자 ID(고유)
+    let id: String
     let nickname: String
 }
 
@@ -35,6 +38,12 @@ private enum FriendAddIntent {
     case clearTapped
     case searchSubmitted
     case rowTapped(FriendSearchItem)
+
+    // 카드 친구 추가 버튼 탭
+    case friendAddButtonTapped
+
+    // 카드 닫기(X) 버튼 탭
+    case cardCloseTapped
 }
 
 // MARK: - Store (@Observable)
@@ -54,6 +63,10 @@ private final class FriendAddStore {
             handleSearchSubmitted()
         case .rowTapped(let item):
             handleRowTapped(item)
+        case .friendAddButtonTapped:
+            handlefriendAddButtonTapped()
+        case .cardCloseTapped:
+            handleCardCloseTapped()
         }
     }
 
@@ -79,6 +92,7 @@ private final class FriendAddStore {
 
         // 선택 상태 초기화(새 검색 시작 시 카드 숨김)
         state.selectedItem = nil
+        state.selectedIsFriend = nil
 
         // 로딩 시작
         state.isLoading = true
@@ -102,6 +116,20 @@ private final class FriendAddStore {
     private func handleRowTapped(_ item: FriendSearchItem) {
         // 선택된 셀로 카드 표시
         state.selectedItem = item
+
+        // TODO: 여기서 서버에 해당 유저의 친구 여부 조회 요청
+        state.selectedIsFriend = nil // 아직 모르는 상태(nil) → 버튼은 "친구 추가"로 노출
+    }
+
+    private func handlefriendAddButtonTapped() {
+        // TODO: 네트워크 통신으로 친구 상태 변경
+        print("친구 추가 버튼 눌림")
+    }
+
+    private func handleCardCloseTapped() {
+        // 카드 닫기: 선택 해제 → 기존 검색 결과 리스트 노출
+        state.selectedItem = nil
+        state.selectedIsFriend = nil
     }
 
     // MARK: - Helpers
@@ -159,10 +187,19 @@ struct FriendAddView: View {
 
             // 선택된 카드가 있으면 카드만 노출, 아니면 기존 결과 영역
             if let selected = store.state.selectedItem {
-                FriendSelectedCard(item: selected)
-                    .padding(.horizontal, 16)
-                    .padding(.top, 12)
-                    .frame(maxWidth: .infinity, maxHeight: 300, alignment: .top)
+                FriendSelectedCard(
+                    item: selected,
+                    buttonTitle: (store.state.selectedIsFriend == true) ? "친구 취소" : "친구 추가",
+                    onButtonTap: {
+                        store.send(.friendAddButtonTapped)
+                    },
+                    onCloseTap: {
+                        store.send(.cardCloseTapped)
+                    }
+                )
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+                .frame(maxWidth: .infinity, maxHeight: 320, alignment: .top)
 
                 Spacer()
             } else {
@@ -274,15 +311,18 @@ private struct FriendIDSearchBar: View {
     }
 }
 
-// MARK: - 선택 카드(심플 버전)
+// MARK: - 친구 선택 카드
 private struct FriendSelectedCard: View {
     let item: FriendSearchItem
+    let buttonTitle: String
+    let onButtonTap: () -> Void
+    let onCloseTap: () -> Void
 
     var body: some View {
         RoundedRectangle(cornerRadius: 16, style: .continuous)
             .fill(Color(uiColor: .secondarySystemBackground))
             .overlay(
-                VStack(spacing: 12) {
+                VStack(spacing: 14) {
                     // 아바타 플레이스홀더
                     ZStack {
                         Circle().fill(Color.gray.opacity(0.15))
@@ -299,10 +339,42 @@ private struct FriendSelectedCard: View {
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     }
+
+                    Button {
+                        // View는 로직을 갖지 않고 Intent만 보냄
+                        onButtonTap()
+                    } label: {
+                        Text(buttonTitle)
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: 140)
+                            .frame(height: 48)
+                            .background(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .fill(Color.orange)
+                            )
+                    }
+                    .buttonStyle(.plain)
                 }
                 .padding(.vertical, 16)
                 .padding(.horizontal, 12)
             )
+            // 카드 우상단 X 버튼
+            .overlay(alignment: .topTrailing) {
+                Button {
+                    onCloseTap()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(.secondary)
+                        .padding(8)
+                        .background(
+                            Circle().fill(Color.black.opacity(0.08))
+                        )
+                }
+                .buttonStyle(.plain)
+                .padding(8) // 카드 모서리와 간격
+            }
     }
 }
 

--- a/Moda/Feature/Friend/Add/FriendAddView.swift
+++ b/Moda/Feature/Friend/Add/FriendAddView.swift
@@ -12,6 +12,18 @@ import Observation
 private struct FriendAddState {
     var query: String = ""
     let maxLength: Int = 20
+
+    // 검색 관련 상태
+    var results: [FriendSearchItem] = []
+    var isLoading: Bool = false
+    var errorMessage: String?
+    var hasSearched: Bool = false // 첫 검색 여부
+}
+
+//MARK: 검색 결과 모델(목 데이터용 간단 모델 추후 수정필요)
+private struct FriendSearchItem: Identifiable, Hashable {
+    let id: String      // 사용자 ID(고유)
+    let nickname: String
 }
 
 // MARK: - Intent
@@ -26,6 +38,7 @@ private enum FriendAddIntent {
 @Observable
 private final class FriendAddStore {
     var state = FriendAddState()
+    private var searchTask: Task<Void, Never>?
 
     func send(_ intent: FriendAddIntent) {
         switch intent {
@@ -45,17 +58,36 @@ private final class FriendAddStore {
     }
 
     private func handleSearchSubmitted() {
-        // 필요 시 공백 제거
+        // 필요 시 공백 제거 + 길이 보정
         let trimmed = state.query.trimmingCharacters(in: .whitespacesAndNewlines)
-        // 트리밍 후에도 길이 보정(붙여넣기/프로그램적 변경 대비)
         state.query = clampToMaxLength(trimmed)
 
         // 빈 입력은 무시
         guard !state.query.isEmpty else { return }
 
-        // TODO: 여기서 실제 검색 로직을 호출하세요.
-        // 예: await service.searchFriend(by: state.query)
-        print("검색내용: \(state.query)")
+        // 첫 검색 실행 표시
+        state.hasSearched = true
+
+        // 이전 검색 취소
+        searchTask?.cancel()
+
+        // 로딩 시작
+        state.isLoading = true
+        state.errorMessage = nil
+        state.results = []
+
+        let query = state.query
+
+        //TODO: 목 네트워크 호출,네트워크로 추후 대체
+        searchTask = Task {
+            do {
+                let items = try await fetchMockResults(for: query)
+                state.results = items
+            } catch {
+                state.errorMessage = error.localizedDescription
+            }
+            state.isLoading = false
+        }
     }
 
     // MARK: - Helpers
@@ -64,6 +96,25 @@ private final class FriendAddStore {
             return String(text.prefix(state.maxLength))
         } else {
             return text
+        }
+    }
+
+    // TODO: 목 데이터 로더, 네트워크로 추후 대체
+    private func fetchMockResults(for query: String) async throws -> [FriendSearchItem] {
+        // 네트워크 지연 흉내
+        try await Task.sleep(for: .milliseconds(700))
+
+        let lower = query.lowercased()
+        // 특정 키워드로 빈/에러 케이스 테스트 가능
+        if lower == "empty" { return [] }
+        if lower == "error" { throw URLError(.badServerResponse) }
+
+        // 간단한 목 결과
+        return (1...8).map { i in
+            FriendSearchItem(
+                id: "\(lower)_\(i)",
+                nickname: "\(query.capitalized) \(i)"
+            )
         }
     }
 }
@@ -92,7 +143,41 @@ struct FriendAddView: View {
                 }
             )
 
-            Spacer()
+            // 결과 영역
+            Group {
+                if store.state.isLoading {
+                    ProgressView("검색 중…")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                } else if let message = store.state.errorMessage {
+                    ContentUnavailableView(
+                        "오류가 발생했어요",
+                        systemImage: "exclamationmark.triangle",
+                        description: Text(message)
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if !store.state.hasSearched {
+                    // 초기 상태(중립 안내): 아직 검색하지 않았을 때
+                    ContentUnavailableView(
+                        "친구를 검색해 보세요",
+                        systemImage: "person.crop.circle.badge.magnifyingglass",
+                        description: Text("ID를 입력하고 검색을 눌러보세요.")
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if store.state.results.isEmpty {
+                    // 검색은 했지만 결과가 없을 때
+                    ContentUnavailableView(
+                        "검색 결과가 없어요",
+                        systemImage: "person.fill.questionmark",
+                        description: Text("다른 ID로 다시 시도해 보세요.")
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    List(store.state.results) { item in
+                        FriendRow(item: item)
+                    }
+                    .listStyle(.plain)
+                }
+            }
         }
         .navigationTitle("ID로 추가")
         .toolbarTitleDisplayMode(.inline)
@@ -104,6 +189,14 @@ struct FriendAddView: View {
                     Image(systemName: "xmark")
                         .font(.system(size: 18, weight: .semibold))
                 }
+            }
+            //TODO: 지금 검색버튼은 프리뷰 시연용, 나중에 어차피 키보드 올라왔을때 submit 버튼 눌렀을때 동작
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("검색") {
+                    store.send(.searchSubmitted)
+                    isSearching = false
+                }
+                .disabled(store.state.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || store.state.isLoading)
             }
         }
         .task {
@@ -129,6 +222,7 @@ private struct FriendIDSearchBar: View {
             HStack(alignment: .firstTextBaseline) {
                 TextField("친구 ID", text: $text)
                     .textInputAutocapitalization(.none)
+                    .keyboardType(.asciiCapable) // 영문/숫자 ID라면 권장
                     .disableAutocorrection(true)
                     .focused($isFocused)
                     .submitLabel(.search)
@@ -137,6 +231,7 @@ private struct FriendIDSearchBar: View {
                     }
 
                 Text("\(text.count)/\(maxLength)")
+                    .monospacedDigit()
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
@@ -147,6 +242,30 @@ private struct FriendIDSearchBar: View {
         }
         .padding(.horizontal, 16)
         .padding(.top, 12)
+    }
+}
+
+// MARK: - Result Row, 나중에 분리, 재활용 고려하기
+private struct FriendRow: View {
+    let item: FriendSearchItem
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "person.circle.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.nickname)
+                    .font(.body.weight(.semibold))
+                Text(item.id)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 6)
     }
 }
 

--- a/Moda/Feature/Friend/Add/FriendAddView.swift
+++ b/Moda/Feature/Friend/Add/FriendAddView.swift
@@ -1,0 +1,157 @@
+//
+//  FriendAddView.swift
+//  Moda
+//
+//  Created by hyunMac on 11/16/25.
+//
+
+import SwiftUI
+import Observation
+
+// MARK: - State
+private struct FriendAddState {
+    var query: String = ""
+    let maxLength: Int = 20
+}
+
+// MARK: - Intent
+private enum FriendAddIntent {
+    case queryChanged(String)
+    case clearTapped
+    case searchSubmitted
+}
+
+// MARK: - Store (@Observable)
+@MainActor
+@Observable
+private final class FriendAddStore {
+    var state = FriendAddState()
+
+    func send(_ intent: FriendAddIntent) {
+        switch intent {
+        case .queryChanged(let text):
+            handleQueryChanged(text)
+        case .clearTapped:
+            state.query = ""
+        case .searchSubmitted:
+            handleSearchSubmitted()
+        }
+    }
+
+    // MARK: - Handlers
+    private func handleQueryChanged(_ text: String) {
+        // 입력 중 최대길이 도달시 입력 방지
+        state.query = clampToMaxLength(text)
+    }
+
+    private func handleSearchSubmitted() {
+        // 필요 시 공백 제거
+        let trimmed = state.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        // 트리밍 후에도 길이 보정(붙여넣기/프로그램적 변경 대비)
+        state.query = clampToMaxLength(trimmed)
+
+        // 빈 입력은 무시
+        guard !state.query.isEmpty else { return }
+
+        // TODO: 여기서 실제 검색 로직을 호출하세요.
+        // 예: await service.searchFriend(by: state.query)
+        print("검색내용: \(state.query)")
+    }
+
+    // MARK: - Helpers
+    private func clampToMaxLength(_ text: String) -> String {
+        if text.count > state.maxLength {
+            return String(text.prefix(state.maxLength))
+        } else {
+            return text
+        }
+    }
+}
+
+// MARK: - View
+struct FriendAddView: View {
+    @State private var store = FriendAddStore()
+    @FocusState private var isSearching: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            FriendIDSearchBar(
+                text: Binding(
+                    get: { store.state.query },
+                    set: { store.send(.queryChanged($0)) }
+                ),
+                isFocused: _isSearching,
+                maxLength: store.state.maxLength,
+                onSubmit: {
+                    // 키보드의 Search 버튼을 눌렀을 때만 검색
+                    store.send(.searchSubmitted)
+                    isSearching = false
+                }, onClear: {
+                    store.send(.clearTapped)
+                }
+            )
+
+            Spacer()
+        }
+        .navigationTitle("ID로 추가")
+        .toolbarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 18, weight: .semibold))
+                }
+            }
+        }
+        .task {
+            // 진입 시 키보드 살짝 지연 후 포커스
+            try? await Task.sleep(for: .milliseconds(250))
+            await MainActor.run {
+                isSearching = true
+            }
+        }
+    }
+}
+
+// MARK: - Search Bar
+private struct FriendIDSearchBar: View {
+    @Binding var text: String
+    @FocusState var isFocused: Bool
+    let maxLength: Int
+    let onSubmit: () -> Void
+    let onClear: () -> Void
+
+    var body: some View {
+        VStack(spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                TextField("친구 ID", text: $text)
+                    .textInputAutocapitalization(.none)
+                    .disableAutocorrection(true)
+                    .focused($isFocused)
+                    .submitLabel(.search)
+                    .onSubmit {
+                        onSubmit()
+                    }
+
+                Text("\(text.count)/\(maxLength)")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            // 언더라인
+            Rectangle()
+                .fill(Color.primary.opacity(0.2))
+                .frame(height: 1)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        FriendAddView()
+    }
+}

--- a/Moda/Feature/Friend/Add/FriendAddView.swift
+++ b/Moda/Feature/Friend/Add/FriendAddView.swift
@@ -18,6 +18,9 @@ private struct FriendAddState {
     var isLoading: Bool = false
     var errorMessage: String?
     var hasSearched: Bool = false // 첫 검색 여부
+
+    // 선택된 셀(선택 시 목록 숨기고 카드만 노출)
+    var selectedItem: FriendSearchItem?
 }
 
 //MARK: 검색 결과 모델(목 데이터용 간단 모델 추후 수정필요)
@@ -31,6 +34,7 @@ private enum FriendAddIntent {
     case queryChanged(String)
     case clearTapped
     case searchSubmitted
+    case rowTapped(FriendSearchItem)
 }
 
 // MARK: - Store (@Observable)
@@ -48,6 +52,8 @@ private final class FriendAddStore {
             state.query = ""
         case .searchSubmitted:
             handleSearchSubmitted()
+        case .rowTapped(let item):
+            handleRowTapped(item)
         }
     }
 
@@ -71,6 +77,9 @@ private final class FriendAddStore {
         // 이전 검색 취소
         searchTask?.cancel()
 
+        // 선택 상태 초기화(새 검색 시작 시 카드 숨김)
+        state.selectedItem = nil
+
         // 로딩 시작
         state.isLoading = true
         state.errorMessage = nil
@@ -78,7 +87,7 @@ private final class FriendAddStore {
 
         let query = state.query
 
-        //TODO: 목 네트워크 호출,네트워크로 추후 대체
+        // TODO: 목 네트워크 호출, 네트워크로 추후 대체
         searchTask = Task {
             do {
                 let items = try await fetchMockResults(for: query)
@@ -88,6 +97,11 @@ private final class FriendAddStore {
             }
             state.isLoading = false
         }
+    }
+
+    private func handleRowTapped(_ item: FriendSearchItem) {
+        // 선택된 셀로 카드 표시
+        state.selectedItem = item
     }
 
     // MARK: - Helpers
@@ -143,39 +157,54 @@ struct FriendAddView: View {
                 }
             )
 
-            // 결과 영역
-            Group {
-                if store.state.isLoading {
-                    ProgressView("검색 중…")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-                } else if let message = store.state.errorMessage {
-                    ContentUnavailableView(
-                        "오류가 발생했어요",
-                        systemImage: "exclamationmark.triangle",
-                        description: Text(message)
-                    )
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if !store.state.hasSearched {
-                    // 초기 상태(중립 안내): 아직 검색하지 않았을 때
-                    ContentUnavailableView(
-                        "친구를 검색해 보세요",
-                        systemImage: "person.crop.circle.badge.magnifyingglass",
-                        description: Text("ID를 입력하고 검색을 눌러보세요.")
-                    )
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if store.state.results.isEmpty {
-                    // 검색은 했지만 결과가 없을 때
-                    ContentUnavailableView(
-                        "검색 결과가 없어요",
-                        systemImage: "person.fill.questionmark",
-                        description: Text("다른 ID로 다시 시도해 보세요.")
-                    )
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else {
-                    List(store.state.results) { item in
-                        FriendRow(item: item)
+            // 선택된 카드가 있으면 카드만 노출, 아니면 기존 결과 영역
+            if let selected = store.state.selectedItem {
+                FriendSelectedCard(item: selected)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 12)
+                    .frame(maxWidth: .infinity, maxHeight: 300, alignment: .top)
+
+                Spacer()
+            } else {
+                // 결과 영역
+                Group {
+                    if store.state.isLoading {
+                        ProgressView("검색 중…")
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                    } else if let message = store.state.errorMessage {
+                        ContentUnavailableView(
+                            "오류가 발생했어요",
+                            systemImage: "exclamationmark.triangle",
+                            description: Text(message)
+                        )
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else if !store.state.hasSearched {
+                        // 초기 상태(중립 안내): 아직 검색하지 않았을 때
+                        ContentUnavailableView(
+                            "친구를 검색해 보세요",
+                            systemImage: "person.crop.circle.badge.magnifyingglass",
+                            description: Text("ID를 입력하고 검색을 눌러보세요.")
+                        )
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else if store.state.results.isEmpty {
+                        // 검색은 했지만 결과가 없을 때
+                        ContentUnavailableView(
+                            "검색 결과가 없어요",
+                            systemImage: "person.fill.questionmark",
+                            description: Text("다른 ID로 다시 시도해 보세요.")
+                        )
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else {
+                        List(store.state.results) { item in
+                            Button {
+                                store.send(.rowTapped(item))
+                                isSearching = false
+                            } label: {
+                                FriendRow(item: item)
+                            }
+                        }
+                        .listStyle(.plain)
                     }
-                    .listStyle(.plain)
                 }
             }
         }
@@ -190,7 +219,7 @@ struct FriendAddView: View {
                         .font(.system(size: 18, weight: .semibold))
                 }
             }
-            //TODO: 지금 검색버튼은 프리뷰 시연용, 나중에 어차피 키보드 올라왔을때 submit 버튼 눌렀을때 동작
+            //MARK: 지금 검색버튼은 프리뷰 시연용, 나중에 어차피 키보드 올라왔을때 submit 버튼 눌렀을때 동작
             ToolbarItem(placement: .topBarTrailing) {
                 Button("검색") {
                     store.send(.searchSubmitted)
@@ -242,6 +271,38 @@ private struct FriendIDSearchBar: View {
         }
         .padding(.horizontal, 16)
         .padding(.top, 12)
+    }
+}
+
+// MARK: - 선택 카드(심플 버전)
+private struct FriendSelectedCard: View {
+    let item: FriendSearchItem
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .fill(Color(uiColor: .secondarySystemBackground))
+            .overlay(
+                VStack(spacing: 12) {
+                    // 아바타 플레이스홀더
+                    ZStack {
+                        Circle().fill(Color.gray.opacity(0.15))
+                        Image(systemName: "person.fill")
+                            .font(.system(size: 28))
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(width: 72, height: 72)
+
+                    VStack(spacing: 4) {
+                        Text(item.nickname)
+                            .font(.headline)
+                        Text("ID: \(item.id)")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.vertical, 16)
+                .padding(.horizontal, 12)
+            )
     }
 }
 

--- a/Moda/Feature/Friend/Search/FriendSearchView.swift
+++ b/Moda/Feature/Friend/Search/FriendSearchView.swift
@@ -82,7 +82,7 @@ struct FriendSearchView: View {
         VStack(spacing: 0) {
             // 상단 검색 영역 (서치바)
             HStack(spacing: 8) {
-                SearchField(
+                FriendSearchBar(
                     text: Binding(
                         get: { store.state.query },
                         set: { store.send(.queryChanged($0)) }
@@ -137,7 +137,7 @@ struct FriendSearchView: View {
 }
 
 // MARK: - Search Field
-private struct SearchField: View {
+private struct FriendSearchBar: View {
     @Binding var text: String
     @FocusState var isFocused: Bool
     var onClear: () -> Void


### PR DESCRIPTION
# Pull requests

## 작업한 브랜치
> 관련된 이슈 번호를 적어주세요.  
> ex - #0
- #16 

## 작업한 내용
> 이번 PR에서 수행한 주요 작업 내용을 간략히 작성해주세요.
- 친구를 ID로 검색후 친구를 추가하는 뷰를 생성했습니다
- 서치바 구현, 검색시 목 데이터로 해당 닉네임들의 셀을 보여줍니다
- 검색시 데이터 없는경우, 에러 발생의 경우의 대응을 하였습니다, (Error, Emtpy 키워드로 서치시 확인가능)
- 검색된 셀을 클릭시 해당 유저의 정보와 친구 추가 버튼을 가진 카드를 보여줍니다

## 참고 사항
> 이외 참고할 만한 내용이 있다면 작성해주세요.
- 지금은 목 데이터로 테스트 했으며 네트워크 연결이 필요합니다
- 프리뷰에서 확인하기 쉽도록 네비게이션바 상단에 검색 버튼이 있습니다 (추후 삭제예정)
- MVI로 진행하며 발생한 에러가 있습니다. 아이디 20자리 이상 입력이 계속되는 문제가 있습니다.
> 
## 스크린샷
> 시각적으로 확인이 필요한 경우 첨부해주세요.

|친구추가 뷰|
|:--:|

https://github.com/user-attachments/assets/c0b3d8fb-f937-40fb-8482-2d5be5120e9c

