### PR TITLE
20 친구탭 디테일 뷰 구현

### DIFF
--- a/Moda/Core/Navigation/NavigationDestination.swift
+++ b/Moda/Core/Navigation/NavigationDestination.swift
@@ -77,6 +77,16 @@ enum NavigationDestination: Hashable {
 
     /// 물건 올리기 화면
     case productUpload
+
+    // MARK: FriendTab
+    /// 친구 검색 화면
+    case friendSearch
+
+    /// 친구 추가화 면
+    case friendAdd
+
+    /// 프로필 디테일 화면
+    case profileDetail
 }
 
 // MARK: - View Mapping
@@ -103,6 +113,15 @@ extension NavigationDestination {
             Text("Settings View")
         case .productUpload:
             ProductUploadView()
+
+        //MARK: FriendTab
+        case .friendSearch:
+            FriendSearchView()
+        case .friendAdd:
+            FriendAddView()
+        case .profileDetail:
+            ProfileDetailView()
         }
+
     }
 }

--- a/Moda/Feature/Friend/Detail/ProfileDetailView.swift
+++ b/Moda/Feature/Friend/Detail/ProfileDetailView.swift
@@ -1,0 +1,243 @@
+//
+//  ProfileDetailView.swift
+//  Moda
+//
+//  Created by hyunMac on 11/17/25.
+//
+
+import SwiftUI
+import Observation
+
+// MARK: - Model
+private enum ProfileTab: String, CaseIterable, Identifiable {
+    case myItems
+    case likeItems
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .myItems: return "내물건"
+        case .likeItems: return "찜한목록"
+        }
+    }
+}
+
+// MARK: - State
+private struct ProfileDetailState {
+    // 입력/환경
+    var isCurrentUser: Bool = true
+
+    // 화면 상태
+    var nickname: String = "나의 닉네임"
+    var selectedTab: ProfileTab = .myItems
+
+    // 데이터
+    // MARK: 지금은 프로필 디테일 뷰 목 데이터로 보여주기
+    var myItems: [PostCard] = PostCard.mockData
+    var likedItems: [PostCard] = Array(PostCard.mockData.prefix(3))
+
+    // 편의
+    var currentList: [PostCard] {
+        selectedTab == .myItems ? myItems : likedItems
+    }
+}
+
+// MARK: - Intent
+private enum ProfileDetailIntent {
+    case onAppear
+    case selectTab(ProfileTab)
+    case editTapped
+    case uploadTapped
+}
+
+// MARK: - Store (@Observable)
+@MainActor
+@Observable
+private final class ProfileDetailStore {
+
+    var state = ProfileDetailState()
+
+    func send(_ intent: ProfileDetailIntent) {
+        switch intent {
+        case .onAppear:
+            handleOnAppear()
+        case .selectTab(let tab):
+            handleSelectTab(tab)
+        case .editTapped:
+            handleEditTapped()
+        case .uploadTapped:
+            handleUploadTapped()
+        }
+    }
+
+    // MARK: - Handlers
+    private func handleOnAppear() {
+        if state.isCurrentUser == false {
+            state.nickname = "친구 닉네임"
+        } else {
+            state.nickname = "나의 닉네임"
+        }
+    }
+
+    private func handleSelectTab(_ tab: ProfileTab) {
+        state.selectedTab = tab
+    }
+
+    private func handleEditTapped() {
+        print("수정 버튼 탭")
+    }
+
+    private func handleUploadTapped() {
+        print("물건 올리기 버튼 탭")
+    }
+}
+
+// MARK: - View
+struct ProfileDetailView: View {
+    @State private var store = ProfileDetailStore()
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ZStack {
+            content
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 18, weight: .semibold))
+                }
+            }
+            if store.state.isCurrentUser {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("수정") {
+                        store.send(.editTapped)
+                    }
+                    .font(.body.weight(.semibold))
+                }
+            }
+        }
+        .overlay(alignment: .bottomTrailing) {
+            if store.state.isCurrentUser {
+                FloatingUploadButton(title: "물건 올리기") {
+                    store.send(.uploadTapped)
+                }
+                .padding(.trailing, 16)
+                .padding(.bottom, 24)
+            }
+        }
+        .task { store.send(.onAppear) }
+    }
+
+    private var content: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                header
+
+                if store.state.isCurrentUser {
+                    segment
+                }
+
+                productGrid
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 80) // 플로팅 버튼 영역 확보
+        }
+        .scrollIndicators(.hidden)
+    }
+
+    private var header: some View {
+        VStack(spacing: 10) {
+            // 아바타 플레이스홀더
+            ZStack {
+                Circle().fill(Color.gray.opacity(0.2))
+                Image(systemName: "person.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 72, height: 72)
+
+            Text(store.state.nickname)
+                .font(.headline.weight(.semibold))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+    }
+
+    private var segment: some View {
+        Picker("", selection: Binding(
+            get: { store.state.selectedTab },
+            set: { store.send(.selectTab($0)) }
+        )) {
+            ForEach(ProfileTab.allCases) { tab in
+                Text(tab.title).tag(tab)
+            }
+        }
+        .pickerStyle(.segmented)
+    }
+
+    // MARK: - 물건 아이템을 목데이터로 보여주기 임시 뷰, 수정 필요
+    private var productGrid: some View {
+        let items: [PostCard] = store.state.isCurrentUser
+            ? (store.state.selectedTab == .myItems ? store.state.myItems : store.state.likedItems)
+            : store.state.myItems
+
+        return VStack(alignment: .leading, spacing: 12) {
+            if items.isEmpty {
+                Text(store.state.isCurrentUser && store.state.selectedTab == .likeItems ? "찜한 물건이 없어요" : "등록된 물건이 없어요")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 40)
+            } else {
+                HStack(alignment: .top, spacing: 12) {
+                    // 좌/우 컬럼으로 간단한 masonry
+                    LazyVStack(spacing: 12) {
+                        ForEach(Array(items.enumerated()).filter { $0.offset % 2 == 0 }, id: \.element.id) { _, product in
+                            PostCardView(product: product, store: FeedViewStore())
+                        }
+                    }
+                    LazyVStack(spacing: 12) {
+                        ForEach(Array(items.enumerated()).filter { $0.offset % 2 == 1 }, id: \.element.id) { _, product in
+                            PostCardView(product: product, store: FeedViewStore())
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Subviews
+private struct FloatingUploadButton: View {
+    let title: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 16)
+                .frame(height: 48)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color.orange)
+                )
+        }
+        .buttonStyle(.plain)
+        .shadow(color: .black.opacity(0.15), radius: 6, x: 0, y: 3)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        VStack(spacing: 12) {
+            ProfileDetailView()
+                .navigationTitle("프로필")
+        }
+    }
+}

--- a/Moda/Feature/Friend/List/FriendListView.swift
+++ b/Moda/Feature/Friend/List/FriendListView.swift
@@ -29,7 +29,6 @@ struct FriendListView: View {
         statusMessage: "상태 메시지 예시 입니다.",
         profileImageURL: generateDummyProfileImageURL()
     )
-
     // 친구 목록 (더미데이터)
     @State private var friends: [People] = [
         People(id: UUID(), name: "영훈", statusMessage: "주말엔 등산!", profileImageURL: generateDummyProfileImageURL(size: 200)),
@@ -38,12 +37,18 @@ struct FriendListView: View {
         People(id: UUID(), name: "장수지", statusMessage: nil, profileImageURL: generateDummyProfileImageURL(size: 200)),
         People(id: UUID(), name: "금가경", statusMessage: "과제 중", profileImageURL: generateDummyProfileImageURL(size: 200))
     ]
+    // 네비게이션
+    @EnvironmentObject var navigator: AppNavigator
 
     var body: some View {
         List {
             // 내 프로필 섹션
             Section {
                 MyProfileHeader(people: myProfile)
+                    .onTapGesture {
+                        // 내 프로필 상세
+                        navigator.push(.profileDetail)
+                    }
                     .listRowSeparator(.hidden)
                     .listRowBackground(Color.clear)
                     .listRowInsets(.init(top: 8, leading: 16, bottom: 8, trailing: 16))
@@ -52,6 +57,9 @@ struct FriendListView: View {
             Section {
                 ForEach(friends) { person in
                     FriendRow(people: person)
+                        .onTapGesture {
+                            navigator.push(.profileDetail)
+                        }
                 }
             } header: {
                 Text("친구 \(friends.count)")
@@ -66,13 +74,13 @@ struct FriendListView: View {
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 Button {
-                    // TODO: 친구 검색 화면
+                    navigator.push(.friendSearch)
                 } label: {
                     Image(systemName: "magnifyingglass")
                 }
 
                 Button {
-                    // TODO: 친구 추가 화면
+                    navigator.push(.friendAdd)
                 } label: {
                     Image(systemName: "person.badge.plus")
                 }
@@ -170,4 +178,5 @@ private struct ProfileImageView: View {
     NavigationStack {
         FriendListView()
     }
+    .environmentObject(AppNavigator.shared)
 }

--- a/Moda/Feature/MainTabView.swift
+++ b/Moda/Feature/MainTabView.swift
@@ -53,7 +53,7 @@ struct MainTabView: View {
         case .map:
             PlaceholderView(title: "지도")
         case .friends:
-            PlaceholderView(title: "친구")
+            FriendListView()
         case .chat:
             PlaceholderView(title: "채팅")
         case .profile:


### PR DESCRIPTION
# Pull requests

## 작업한 브랜치
> 관련된 이슈 번호를 적어주세요.  
> ex - #0
- #20 

## 작업한 내용
> 이번 PR에서 수행한 주요 작업 내용을 간략히 작성해주세요.
- 친구탭 프로필 상세 UI구현

## 참고 사항
> 이외 참고할 만한 내용이 있다면 작성해주세요.
- 내 프로필 일 경우, 친구 프로필경우 분기 (수정버튼, 물건올리기 버튼, 찜한목록 보여주기 차이가 있습니다) (xcode 프리뷰에서 확인가능)
- 이전 화면에서 이어지는 데이터 주입 로직이 필요합니다
- 네비게이션 정리 필요
- 수정 버튼 UI 추가 필요
> 
## 스크린샷
> 시각적으로 확인이 필요한 경우 첨부해주세요.

|친구 탭 프로필보기(내 프로필)|
|:--:|
|<img width="300" height="650" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-18 at 00 27 20" src="https://github.com/user-attachments/assets/c134a16d-667f-4780-bf5e-466e20fa5819" />|
