### PR TITLE
54 친구 디테일 뷰 api 연동

### DIFF
--- a/Moda/Core/Navigation/NavigationDestination.swift
+++ b/Moda/Core/Navigation/NavigationDestination.swift
@@ -89,8 +89,7 @@ enum NavigationDestination: Hashable {
     case friendAdd
 
     /// 프로필 디테일 화면
-    case profileDetail
-
+    case profileDetail(people: People, isCurrentUser: Bool)
 
     // MARK: ChatTab
     /// 채팅방 화면
@@ -130,8 +129,8 @@ extension NavigationDestination {
             FriendSearchView(friends: friends)
         case .friendAdd:
             FriendAddView()
-        case .profileDetail:
-            ProfileDetailView()
+        case .profileDetail(let people, let isCurrentUser):
+            ProfileDetailView(people: people, isCurrentUser: isCurrentUser)
 
         //MARK: ChatTab
         case .chatRoom(let roomId, let participantName):

--- a/Moda/Feature/Friend/Detail/ProfileDetailView.swift
+++ b/Moda/Feature/Friend/Detail/ProfileDetailView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import Observation
 import Kingfisher
+import Combine
 
 // MARK: - Model
 private enum ProfileTab: String, CaseIterable, Identifiable {
@@ -28,36 +29,47 @@ private enum ProfileTab: String, CaseIterable, Identifiable {
 private struct ProfileDetailState {
     // 입력/환경
     var isCurrentUser: Bool = true
+    var userId: String
 
     // 화면 상태
-    var nickname: String = "나의 닉네임"
+    var nickname: String = "닉네임"
     var profileImageURL: URL? = nil
     var selectedTab: ProfileTab = .myItems
 
     // 데이터
-    // MARK: 지금은 프로필 디테일 뷰 목 데이터로 보여주기
-    var myItems: [PostCard] = PostCard.mockData
-    var likedItems: [PostCard] = Array(PostCard.mockData.prefix(3))
+    var userPosts: [PostCard] = []
+    var likedPosts: [PostCard] = []
+
+    // 페이지네이션/로딩
+    var nextCursorUser: String = ""
+    var nextCursorLiked: String = ""
+    var hasMoreUser: Bool = true
+    var hasMoreLiked: Bool = true
+
+    var isLoading: Bool = false
+    var errorMessage: String?
 
     // 편의
     var currentList: [PostCard] {
-        selectedTab == .myItems ? myItems : likedItems
+        if isCurrentUser {
+            return selectedTab == .myItems ? userPosts : likedPosts
+        } else {
+            return userPosts
+        }
     }
 
     init(
+        userId: String,
         isCurrentUser: Bool = true,
         nickname: String = "닉네임",
         profileImageURL: URL? = nil,
-        selectedTab: ProfileTab = .myItems,
-        myItems: [PostCard] = PostCard.mockData,
-        likedItems: [PostCard] = Array(PostCard.mockData.prefix(3))
+        selectedTab: ProfileTab = .myItems
     ) {
+        self.userId = userId
         self.isCurrentUser = isCurrentUser
         self.nickname = nickname
         self.profileImageURL = profileImageURL
         self.selectedTab = selectedTab
-        self.myItems = myItems
-        self.likedItems = likedItems
     }
 }
 
@@ -67,6 +79,10 @@ private enum ProfileDetailIntent {
     case selectTab(ProfileTab)
     case editTapped
     case uploadTapped
+
+    case loadMore
+    case refresh
+    case toggleLike(String)
 }
 
 // MARK: - Store (@Observable)
@@ -76,30 +92,70 @@ private final class ProfileDetailStore {
 
     var state: ProfileDetailState
 
-    init(initial: ProfileDetailState = .init()) {
+    // API
+    private let postAPI: PostAPIProtocol
+
+    // Combine for debounced like
+    private var cancellables = Set<AnyCancellable>()
+    private let likeSubject = PassthroughSubject<String, Never>()
+    private var pendingLikeStates: [String: Bool] = [:]
+
+    init(initial: ProfileDetailState, postAPI: PostAPIProtocol = PostAPI.shared) {
         self.state = initial
+        self.postAPI = postAPI
+        setupCombine()
     }
 
     func send(_ intent: ProfileDetailIntent) {
         switch intent {
         case .onAppear:
             handleOnAppear()
+
         case .selectTab(let tab):
             handleSelectTab(tab)
+
         case .editTapped:
             handleEditTapped()
+
         case .uploadTapped:
             handleUploadTapped()
+
+        case .loadMore:
+            handleLoadMore()
+
+        case .refresh:
+            handleRefresh()
+
+        case .toggleLike(let postId):
+            toggleLikeWithDebounce(postId: postId)
         }
+    }
+
+    // MARK: - Combine
+    private func setupCombine() {
+        likeSubject
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .sink { [weak self] postId in
+                Task { @MainActor in
+                    await self?.sendLikeRequest(postId: postId)
+                }
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Handlers
     private func handleOnAppear() {
-        // 현재는 외부에서 주입받은 값 그대로 사용
+        // 초기에는 사용자 게시글 로드
+        if state.userPosts.isEmpty {
+            Task { await fetchUserPosts(refresh: true) }
+        }
     }
 
     private func handleSelectTab(_ tab: ProfileTab) {
         state.selectedTab = tab
+        if state.isCurrentUser && tab == .likeItems && state.likedPosts.isEmpty {
+            Task { await fetchLikedPosts(refresh: true) }
+        }
     }
 
     private func handleEditTapped() {
@@ -109,16 +165,198 @@ private final class ProfileDetailStore {
     private func handleUploadTapped() {
         print("물건 올리기 버튼 탭")
     }
+
+    private func handleLoadMore() {
+        guard !state.isLoading else { return }
+
+        if state.isCurrentUser && state.selectedTab == .likeItems {
+            guard state.hasMoreLiked else { return }
+            Task { await fetchLikedPosts(refresh: false) }
+        } else {
+            guard state.hasMoreUser else { return }
+            Task { await fetchUserPosts(refresh: false) }
+        }
+    }
+
+    private func handleRefresh() {
+        if state.isCurrentUser && state.selectedTab == .likeItems {
+            Task { await fetchLikedPosts(refresh: true) }
+        } else {
+            Task { await fetchUserPosts(refresh: true) }
+        }
+    }
+
+    // MARK: - API Calls
+    private func fetchUserPosts(refresh: Bool) async {
+        if refresh {
+            state.nextCursorUser = ""
+            state.hasMoreUser = true
+        }
+        guard state.hasMoreUser else { return }
+
+        state.isLoading = true
+        state.errorMessage = nil
+
+        do {
+            let cursor = refresh ? nil : (state.nextCursorUser.isEmpty ? nil : state.nextCursorUser)
+            let response = try await postAPI.getUserPosts(
+                userId: state.userId,
+                next: cursor,
+                limit: "20",
+                category: nil
+            )
+
+            let currentUserId = UserDefaults.standard.string(forKey: "userId")
+            var newPosts = response.data.map { $0.toDomain().toPostCard(currentUserId: currentUserId) }
+
+            // 최신순 정렬
+            newPosts.sort { $0.createdAt > $1.createdAt }
+
+            if refresh {
+                state.userPosts = newPosts
+            } else {
+                let existingIds = Set(state.userPosts.map { $0.id })
+                let unique = newPosts.filter { !existingIds.contains($0.id) }
+                state.userPosts.append(contentsOf: unique)
+            }
+
+            state.nextCursorUser = response.nextCursor
+            state.hasMoreUser = !response.nextCursor.isEmpty && response.nextCursor != "0"
+        } catch {
+            state.errorMessage = error.localizedDescription
+            print("사용자 게시글 로드 실패: \(error.localizedDescription)")
+        }
+
+        state.isLoading = false
+    }
+
+    private func fetchLikedPosts(refresh: Bool) async {
+        if refresh {
+            state.nextCursorLiked = ""
+            state.hasMoreLiked = true
+        }
+        guard state.hasMoreLiked else { return }
+
+        state.isLoading = true
+        state.errorMessage = nil
+
+        do {
+            let cursor = refresh ? nil : (state.nextCursorLiked.isEmpty ? nil : state.nextCursorLiked)
+            let response = try await postAPI.getMyLikedPosts(
+                next: cursor,
+                limit: "20",
+                category: nil
+            )
+
+            let currentUserId = UserDefaults.standard.string(forKey: "userId")
+            var newPosts = response.data.map { $0.toDomain().toPostCard(currentUserId: currentUserId) }
+            newPosts.sort { $0.createdAt > $1.createdAt }
+
+            if refresh {
+                state.likedPosts = newPosts
+            } else {
+                let existingIds = Set(state.likedPosts.map { $0.id })
+                let unique = newPosts.filter { !existingIds.contains($0.id) }
+                state.likedPosts.append(contentsOf: unique)
+            }
+
+            state.nextCursorLiked = response.nextCursor
+            state.hasMoreLiked = !response.nextCursor.isEmpty && response.nextCursor != "0"
+        } catch {
+            state.errorMessage = error.localizedDescription
+            print("찜한 게시글 로드 실패: \(error.localizedDescription)")
+        }
+
+        state.isLoading = false
+    }
+
+    // MARK: - Like with Debouncing
+    private func toggleLikeWithDebounce(postId: String) {
+        // 현재 탭 기준으로 먼저 UI 반영
+        updateLikeUI(postId: postId) { newState in
+            pendingLikeStates[postId] = newState
+            likeSubject.send(postId)
+        }
+    }
+
+    private func updateLikeUI(postId: String, completion: (Bool) -> Void) {
+        // userPosts
+        if let idx = state.userPosts.firstIndex(where: { $0.id == postId }) {
+            state.userPosts[idx].isLiked.toggle()
+            let newState = state.userPosts[idx].isLiked
+            if newState {
+                state.userPosts[idx].likeCount += 1
+            } else {
+                state.userPosts[idx].likeCount = max(0, state.userPosts[idx].likeCount - 1)
+            }
+            completion(newState)
+            // liked 탭에서도 동일 id가 있으면 동기화
+            if let lidx = state.likedPosts.firstIndex(where: { $0.id == postId }) {
+                state.likedPosts[lidx].isLiked = state.userPosts[idx].isLiked
+                state.likedPosts[lidx].likeCount = state.userPosts[idx].likeCount
+            }
+            return
+        }
+
+        // likedPosts
+        if let idx = state.likedPosts.firstIndex(where: { $0.id == postId }) {
+            state.likedPosts[idx].isLiked.toggle()
+            let newState = state.likedPosts[idx].isLiked
+            if newState {
+                state.likedPosts[idx].likeCount += 1
+            } else {
+                state.likedPosts[idx].likeCount = max(0, state.likedPosts[idx].likeCount - 1)
+            }
+            completion(newState)
+            // user 탭에서도 동일 id가 있으면 동기화
+            if let uidx = state.userPosts.firstIndex(where: { $0.id == postId }) {
+                state.userPosts[uidx].isLiked = state.likedPosts[idx].isLiked
+                state.userPosts[uidx].likeCount = state.likedPosts[idx].likeCount
+            }
+            return
+        }
+    }
+
+    private func sendLikeRequest(postId: String) async {
+        guard let likeStatus = pendingLikeStates[postId] else { return }
+        do {
+            _ = try await postAPI.likePost(postId: postId, likeStatus: likeStatus)
+            pendingLikeStates.removeValue(forKey: postId)
+        } catch {
+            // 실패 시 롤백
+            rollbackLikeUI(postId: postId)
+            print("좋아요 요청 실패: \(error.localizedDescription)")
+        }
+    }
+
+    private func rollbackLikeUI(postId: String) {
+        if let idx = state.userPosts.firstIndex(where: { $0.id == postId }) {
+            state.userPosts[idx].isLiked.toggle()
+            if state.userPosts[idx].isLiked {
+                state.userPosts[idx].likeCount += 1
+            } else {
+                state.userPosts[idx].likeCount = max(0, state.userPosts[idx].likeCount - 1)
+            }
+        }
+        if let idx = state.likedPosts.firstIndex(where: { $0.id == postId }) {
+            state.likedPosts[idx].isLiked.toggle()
+            if state.likedPosts[idx].isLiked {
+                state.likedPosts[idx].likeCount += 1
+            } else {
+                state.likedPosts[idx].likeCount = max(0, state.likedPosts[idx].likeCount - 1)
+            }
+        }
+    }
 }
 
 // MARK: - View
 struct ProfileDetailView: View {
     @State private var store: ProfileDetailStore
-    @Environment(\.dismiss) private var dismiss
 
     // FriendListView에서 전달받아 초기 상태 구성
     init(people: People, isCurrentUser: Bool) {
         let initial = ProfileDetailState(
+            userId: people.id,
             isCurrentUser: isCurrentUser,
             nickname: people.name,
             profileImageURL: people.profileImageURL
@@ -127,8 +365,35 @@ struct ProfileDetailView: View {
     }
 
     var body: some View {
-        ZStack {
-            content
+        GeometryReader { geometry in
+            let spacing: CGFloat = 12
+            let horizontalPadding: CGFloat = 16
+            let itemWidth = (geometry.size.width - horizontalPadding * 2 - spacing) / 2
+
+            ZStack {
+                Color.white.ignoresSafeArea()
+
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: 16) {
+                        header
+
+                        if store.state.isCurrentUser {
+                            segment
+                        }
+
+                        productGrid(itemWidth: itemWidth, spacing: spacing, horizontalPadding: horizontalPadding)
+                    }
+                    .padding(.top, 8)
+                    .padding(.bottom, 80) // 플로팅 버튼 영역 확보
+                }
+                .refreshable {
+                    store.send(.refresh)
+                }
+
+                if store.state.isLoading && store.state.currentList.isEmpty {
+                    ProgressView()
+                }
+            }
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -151,24 +416,6 @@ struct ProfileDetailView: View {
             }
         }
         .task { store.send(.onAppear) }
-    }
-
-    private var content: some View {
-        ScrollView {
-            VStack(spacing: 16) {
-                header
-
-                if store.state.isCurrentUser {
-                    segment
-                }
-
-                productGrid
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 8)
-            .padding(.bottom, 80) // 플로팅 버튼 영역 확보
-        }
-        .scrollIndicators(.hidden)
     }
 
     private var header: some View {
@@ -201,6 +448,7 @@ struct ProfileDetailView: View {
                 .font(.headline.weight(.semibold))
         }
         .frame(maxWidth: .infinity)
+        .padding(.horizontal, 16)
         .padding(.vertical, 8)
     }
 
@@ -214,36 +462,61 @@ struct ProfileDetailView: View {
             }
         }
         .pickerStyle(.segmented)
+        .padding(.horizontal, 16)
     }
 
-    // MARK: - 물건 아이템을 목데이터로 보여주기 임시 뷰, 수정 필요
-    private var productGrid: some View {
-        let items: [PostCard] = store.state.isCurrentUser
-            ? (store.state.selectedTab == .myItems ? store.state.myItems : store.state.likedItems)
-            : store.state.myItems
+    @ViewBuilder
+    private func productGrid(itemWidth: CGFloat, spacing: CGFloat, horizontalPadding: CGFloat) -> some View {
+        let items = store.state.currentList
 
-        return VStack(alignment: .leading, spacing: 12) {
-            if items.isEmpty {
-                Text(store.state.isCurrentUser && store.state.selectedTab == .likeItems ? "찜한 물건이 없어요" : "등록된 물건이 없어요")
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, 40)
-            } else {
-                #warning("임의의 PostCardView")
-                HStack(alignment: .top, spacing: 12) {
-                    // 좌/우 컬럼으로 간단한 masonry
-                    LazyVStack(spacing: 12) {
-                        ForEach(Array(items.enumerated()).filter { $0.offset % 2 == 0 }, id: \.element.id) { _, product in
-                            PostCardView(product: product, itemWidth: 50, currentLocation: nil, onLikeTapped: {})
-                        }
-                    }
-                    LazyVStack(spacing: 12) {
-                        ForEach(Array(items.enumerated()).filter { $0.offset % 2 == 1 }, id: \.element.id) { _, product in
-                            PostCardView(product: product, itemWidth: 50, currentLocation: nil, onLikeTapped: {})
+        if items.isEmpty && store.state.isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity)
+                .padding(.top, 50)
+        } else if items.isEmpty {
+            Text(store.state.isCurrentUser && store.state.selectedTab == .likeItems ? "찜한 물건이 없어요" : "등록된 물건이 없어요")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, 40)
+        } else {
+            HStack(alignment: .top, spacing: spacing) {
+                // 왼쪽 열
+                VStack(spacing: 12) {
+                    ForEach(Array(items.enumerated().filter { $0.offset % 2 == 0 }), id: \.element.id) { index, product in
+                        PostCardView(
+                            product: product,
+                            itemWidth: itemWidth,
+                            currentLocation: nil,
+                            onLikeTapped: { store.send(.toggleLike(product.id)) }
+                        )
+                        .onAppear {
+                            if index >= items.count - 4 {
+                                store.send(.loadMore)
+                            }
                         }
                     }
                 }
+                .frame(width: itemWidth)
+
+                // 오른쪽 열
+                VStack(spacing: 12) {
+                    ForEach(Array(items.enumerated().filter { $0.offset % 2 == 1 }), id: \.element.id) { index, product in
+                        PostCardView(
+                            product: product,
+                            itemWidth: itemWidth,
+                            currentLocation: nil,
+                            onLikeTapped: { store.send(.toggleLike(product.id)) }
+                        )
+                        .onAppear {
+                            if index >= items.count - 4 {
+                                store.send(.loadMore)
+                            }
+                        }
+                    }
+                }
+                .frame(width: itemWidth)
             }
+            .padding(.horizontal, horizontalPadding)
         }
     }
 }

--- a/Moda/Feature/Friend/Detail/ProfileDetailView.swift
+++ b/Moda/Feature/Friend/Detail/ProfileDetailView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import Observation
+import Kingfisher
 
 // MARK: - Model
 private enum ProfileTab: String, CaseIterable, Identifiable {
@@ -30,6 +31,7 @@ private struct ProfileDetailState {
 
     // 화면 상태
     var nickname: String = "나의 닉네임"
+    var profileImageURL: URL? = nil
     var selectedTab: ProfileTab = .myItems
 
     // 데이터
@@ -40,6 +42,22 @@ private struct ProfileDetailState {
     // 편의
     var currentList: [PostCard] {
         selectedTab == .myItems ? myItems : likedItems
+    }
+
+    init(
+        isCurrentUser: Bool = true,
+        nickname: String = "닉네임",
+        profileImageURL: URL? = nil,
+        selectedTab: ProfileTab = .myItems,
+        myItems: [PostCard] = PostCard.mockData,
+        likedItems: [PostCard] = Array(PostCard.mockData.prefix(3))
+    ) {
+        self.isCurrentUser = isCurrentUser
+        self.nickname = nickname
+        self.profileImageURL = profileImageURL
+        self.selectedTab = selectedTab
+        self.myItems = myItems
+        self.likedItems = likedItems
     }
 }
 
@@ -56,7 +74,11 @@ private enum ProfileDetailIntent {
 @Observable
 private final class ProfileDetailStore {
 
-    var state = ProfileDetailState()
+    var state: ProfileDetailState
+
+    init(initial: ProfileDetailState = .init()) {
+        self.state = initial
+    }
 
     func send(_ intent: ProfileDetailIntent) {
         switch intent {
@@ -73,11 +95,7 @@ private final class ProfileDetailStore {
 
     // MARK: - Handlers
     private func handleOnAppear() {
-        if state.isCurrentUser == false {
-            state.nickname = "친구 닉네임"
-        } else {
-            state.nickname = "나의 닉네임"
-        }
+        // 현재는 외부에서 주입받은 값 그대로 사용
     }
 
     private func handleSelectTab(_ tab: ProfileTab) {
@@ -95,8 +113,18 @@ private final class ProfileDetailStore {
 
 // MARK: - View
 struct ProfileDetailView: View {
-    @State private var store = ProfileDetailStore()
+    @State private var store: ProfileDetailStore
     @Environment(\.dismiss) private var dismiss
+
+    // FriendListView에서 전달받아 초기 상태 구성
+    init(people: People, isCurrentUser: Bool) {
+        let initial = ProfileDetailState(
+            isCurrentUser: isCurrentUser,
+            nickname: people.name,
+            profileImageURL: people.profileImageURL
+        )
+        _store = State(initialValue: ProfileDetailStore(initial: initial))
+    }
 
     var body: some View {
         ZStack {
@@ -104,14 +132,6 @@ struct ProfileDetailView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                Button {
-                    dismiss()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 18, weight: .semibold))
-                }
-            }
             if store.state.isCurrentUser {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("수정") {
@@ -153,13 +173,29 @@ struct ProfileDetailView: View {
 
     private var header: some View {
         VStack(spacing: 10) {
-            // 아바타 플레이스홀더
-            ZStack {
-                Circle().fill(Color.gray.opacity(0.2))
-                Image(systemName: "person.fill")
-                    .foregroundStyle(.secondary)
+            // 프로필 이미지
+            Group {
+                if let url = store.state.profileImageURL {
+                    KFImage(url)
+                        .requestModifier(KFHeaders.modifier)
+                        .placeholder {
+                            Circle().fill(Color.gray.opacity(0.2))
+                        }
+                        .cacheOriginalImage()
+                        .fade(duration: 0.2)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 72, height: 72)
+                        .clipShape(Circle())
+                } else {
+                    ZStack {
+                        Circle().fill(Color.gray.opacity(0.2))
+                        Image(systemName: "person.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(width: 72, height: 72)
+                }
             }
-            .frame(width: 72, height: 72)
 
             Text(store.state.nickname)
                 .font(.headline.weight(.semibold))
@@ -185,7 +221,7 @@ struct ProfileDetailView: View {
         let items: [PostCard] = store.state.isCurrentUser
             ? (store.state.selectedTab == .myItems ? store.state.myItems : store.state.likedItems)
             : store.state.myItems
-        
+
         return VStack(alignment: .leading, spacing: 12) {
             if items.isEmpty {
                 Text(store.state.isCurrentUser && store.state.selectedTab == .likeItems ? "찜한 물건이 없어요" : "등록된 물건이 없어요")
@@ -237,8 +273,11 @@ private struct FloatingUploadButton: View {
 #Preview {
     NavigationStack {
         VStack(spacing: 12) {
-            ProfileDetailView()
-                .navigationTitle("프로필")
+            ProfileDetailView(
+                people: People(id: "me", name: "나의 닉네임", statusMessage: "상태메시지", profileImageURL: nil),
+                isCurrentUser: true
+            )
+            .navigationTitle("프로필")
         }
     }
 }

--- a/Moda/Feature/Friend/List/FriendListView.swift
+++ b/Moda/Feature/Friend/List/FriendListView.swift
@@ -128,7 +128,7 @@ struct FriendListView: View {
                     MyProfileHeader(people: my)
                         .onTapGesture {
                             // 내 프로필 상세
-                            navigator.push(.profileDetail)
+                            navigator.push(.profileDetail(people: my, isCurrentUser: true))
                         }
                         .listRowSeparator(.hidden)
                         .listRowBackground(Color.clear)
@@ -151,8 +151,8 @@ struct FriendListView: View {
                     ForEach(friendPeople) { person in
                         FriendRow(people: person)
                             .onTapGesture {
-                                // 친구 프로필 상세로 이동 시 userId를 넘겨서 OtherProfile 로드 가능
-                                navigator.push(.profileDetail)
+                                // 친구 프로필 상세 (친구 정보 전달)
+                                navigator.push(.profileDetail(people: person, isCurrentUser: false))
                             }
                     }
                 }


### PR DESCRIPTION
# Pull requests

## 작업한 브랜치
> 관련된 이슈 번호를 적어주세요.  
> ex - #0
- #54 

## 작업한 내용
> 이번 PR에서 수행한 주요 작업 내용을 간략히 작성해주세요.
- 친구 탭의 친구 리스트뷰에서 내 프로필 클릭시, 친구 프로필 클릭시 디테일 보여주는 화면을 구현, API를 연동했습니다

> 
## 스크린샷
> 시각적으로 확인이 필요한 경우 첨부해주세요.

|친구탭 디테일뷰(사용자)|친구탭 디테일뷰(사용자)|
|:--:|:--:|
|<img width="300" height="650" alt="Simulator Screenshot - iPhone 16e - 2025-11-23 at 23 47 20" src="https://github.com/user-attachments/assets/f17a943a-3379-4047-871a-ed51b9853729" />|<img width="300" height="650" alt="Simulator Screenshot - iPhone 16e - 2025-11-23 at 23 47 26" src="https://github.com/user-attachments/assets/6c0cf299-96f1-4db2-9884-c2d3035ef8dd" />|
