### PR TITLE
친구탭 레이아웃 수정

### DIFF
--- a/Moda/Design/Components/ShimmerView.swift
+++ b/Moda/Design/Components/ShimmerView.swift
@@ -1,0 +1,118 @@
+//
+//  ShimmerView.swift
+//  Moda
+//
+//  Created by 금가경 on 11/25/24.
+//
+
+import SwiftUI
+
+struct ShimmerModifier: ViewModifier {
+    @State private var phase: CGFloat = 0
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(
+                LinearGradient(
+                    gradient: Gradient(colors: [
+                        Color.clear,
+                        Color.white.opacity(0.6),
+                        Color.clear
+                    ]),
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .offset(x: phase)
+                .mask(
+                    Rectangle()
+                        .fill(
+                            LinearGradient(
+                                gradient: Gradient(stops: [
+                                    .init(color: .black, location: 0),
+                                    .init(color: .clear, location: 0.5),
+                                    .init(color: .black, location: 1)
+                                ]),
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .rotationEffect(.degrees(70))
+                        .offset(x: phase)
+                )
+            )
+            .onAppear {
+                withAnimation(
+                    Animation
+                        .linear(duration: 1.5)
+                        .repeatForever(autoreverses: false)
+                ) {
+                    phase = 1000
+                }
+            }
+    }
+}
+
+extension View {
+    func shimmer() -> some View {
+        modifier(ShimmerModifier())
+    }
+}
+
+struct PostCardShimmerView: View {
+    let itemWidth: CGFloat
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.gray5)
+                .frame(width: itemWidth, height: itemWidth)
+                .shimmer()
+
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(Color.gray5)
+                    .frame(width: 24, height: 24)
+                    .shimmer()
+
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.gray5)
+                    .frame(width: 60, height: 12)
+                    .shimmer()
+
+                Spacer()
+
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.gray5)
+                    .frame(width: 40, height: 12)
+                    .shimmer()
+            }
+            .padding(.top, 8)
+            .padding(.bottom, 4)
+
+            VStack(alignment: .leading, spacing: 4) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.gray5)
+                    .frame(height: 14)
+                    .shimmer()
+
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.gray5)
+                    .frame(width: itemWidth * 0.7, height: 14)
+                    .shimmer()
+
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.gray5)
+                    .frame(width: itemWidth * 0.5, height: 12)
+                    .shimmer()
+
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.gray5)
+                    .frame(width: 80, height: 16)
+                    .shimmer()
+            }
+            .padding(.top, 6)
+            .padding(.bottom, 8)
+        }
+        .frame(width: itemWidth, alignment: .leading)
+    }
+}

--- a/Moda/Feature/Friend/Add/FriendAddView.swift
+++ b/Moda/Feature/Friend/Add/FriendAddView.swift
@@ -9,14 +9,12 @@ import SwiftUI
 import Observation
 import Kingfisher
 
-//MARK: 검색 결과 모델
 private struct FriendSearchItem: Identifiable, Hashable {
     let id: String          // userId
     let nickname: String    // nick
     let profileImageURL: URL?
 }
 
-// MARK: - State
 private struct FriendAddState {
     var query: String = ""
     let maxLength: Int = 20
@@ -40,7 +38,6 @@ private struct FriendAddState {
 }
 
 
-// MARK: - Intent
 private enum FriendAddIntent {
     case onAppear
     case queryChanged(String)
@@ -55,7 +52,6 @@ private enum FriendAddIntent {
     case cardCloseTapped
 }
 
-// MARK: - Store (@Observable)
 @MainActor
 @Observable
 private final class FriendAddStore {
@@ -91,7 +87,6 @@ private final class FriendAddStore {
         }
     }
 
-    // MARK: - Handlers
     private func handleOnAppear() {
         // 최초 1회 내 프로필 로드(내 userId 확보)
         guard myUserId == nil else { return }
@@ -230,7 +225,6 @@ private final class FriendAddStore {
         state.isFollowUpdating = false
     }
 
-    // MARK: - Helpers
     private func clampToMaxLength(_ text: String) -> String {
         if text.count > state.maxLength {
             return String(text.prefix(state.maxLength))
@@ -240,95 +234,40 @@ private final class FriendAddStore {
     }
 }
 
-// MARK: - View
 struct FriendAddView: View {
     @State private var store = FriendAddStore()
     @FocusState private var isSearching: Bool
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        VStack(spacing: 0) {
-            FriendIDSearchBar(
-                text: Binding(
-                    get: { store.state.query },
-                    set: { store.send(.queryChanged($0)) }
-                ),
-                isFocused: _isSearching,
-                maxLength: store.state.maxLength,
-                onSubmit: {
-                    // 키보드의 Search 버튼을 눌렀을 때만 검색
-                    store.send(.searchSubmitted)
-                    isSearching = false
-                }, onClear: {
-                    store.send(.clearTapped)
-                }
-            )
+        ZStack {
+            Color.white
+                .ignoresSafeArea()
 
-            // 선택된 카드가 있으면 카드만 노출, 아니면 기존 결과 영역
-            if let selected = store.state.selectedItem {
-                FriendSelectedCard(
-                    item: selected,
-                    isLoading: store.state.isFollowUpdating,
-                    buttonTitle: (store.state.selectedIsFriend == true) ? "친구 취소" : "친구 추가",
-                    onButtonTap: {
-                        store.send(.friendAddButtonTapped)
-                    },
-                    onCloseTap: {
-                        store.send(.cardCloseTapped)
-                    }
-                )
-                .padding(.horizontal, 16)
-                .padding(.top, 12)
-                .frame(maxWidth: .infinity, maxHeight: 320, alignment: .top)
+            VStack(spacing: 0) {
+                searchBarSection
 
-                Spacer()
-            } else {
-                // 결과 영역
-                Group {
-                    if store.state.isLoading {
-                        ProgressView("검색 중…")
-                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-                    } else if let message = store.state.errorMessage {
-                        ContentUnavailableView(
-                            "오류가 발생했어요",
-                            systemImage: "exclamationmark.triangle",
-                            description: Text(message)
-                        )
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    } else if !store.state.hasSearched {
-                        // 초기 상태(중립 안내): 아직 검색하지 않았을 때
-                        ContentUnavailableView(
-                            "친구를 검색해 보세요",
-                            systemImage: "person.crop.circle.badge.magnifyingglass",
-                            description: Text("닉네임을 입력하고 검색을 눌러보세요.")
-                        )
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    } else if store.state.results.isEmpty {
-                        // 검색은 했지만 결과가 없을 때
-                        ContentUnavailableView(
-                            "검색 결과가 없어요",
-                            systemImage: "person.fill.questionmark",
-                            description: Text("다른 닉네임으로 다시 시도해 보세요.")
-                        )
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    } else {
-                        List(store.state.results) { item in
-                            Button {
-                                store.send(.rowTapped(item))
-                                isSearching = false
-                            } label: {
-                                FriendRow(item: item)
-                            }
-                        }
-                        .listStyle(.plain)
-                    }
+                if let selected = store.state.selectedItem {
+                    selectedCardSection(selected: selected)
+                } else {
+                    resultsSection
                 }
             }
         }
         .navigationTitle("닉네임으로 추가")
-        .toolbarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.gray1)
+                }
+            }
+        }
         .task {
-            // 진입 시 내 ID 로드 + 키보드 포커스
             store.send(.onAppear)
             try? await Task.sleep(for: .milliseconds(250))
             await MainActor.run {
@@ -336,9 +275,142 @@ struct FriendAddView: View {
             }
         }
     }
+
+    private var searchBarSection: some View {
+        FriendIDSearchBar(
+            text: Binding(
+                get: { store.state.query },
+                set: { store.send(.queryChanged($0)) }
+            ),
+            isFocused: _isSearching,
+            maxLength: store.state.maxLength,
+            onSubmit: {
+                store.send(.searchSubmitted)
+                isSearching = false
+            }, onClear: {
+                store.send(.clearTapped)
+            }
+        )
+    }
+
+    private func selectedCardSection(selected: FriendSearchItem) -> some View {
+        VStack {
+            FriendSelectedCard(
+                item: selected,
+                isLoading: store.state.isFollowUpdating,
+                buttonTitle: (store.state.selectedIsFriend == true) ? "친구 취소" : "친구 추가",
+                onButtonTap: {
+                    store.send(.friendAddButtonTapped)
+                },
+                onCloseTap: {
+                    store.send(.cardCloseTapped)
+                }
+            )
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .frame(maxWidth: .infinity, maxHeight: 320, alignment: .top)
+
+            Spacer()
+        }
+    }
+
+    private var resultsSection: some View {
+        Group {
+            if store.state.isLoading {
+                loadingSection
+            } else if let message = store.state.errorMessage {
+                errorSection(message: message)
+            } else if !store.state.hasSearched {
+                emptySearchSection
+            } else if store.state.results.isEmpty {
+                noResultsSection
+            } else {
+                searchResultsList
+            }
+        }
+    }
+
+    private var loadingSection: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            ProgressView()
+            Text("검색 중…")
+                .Body1()
+                .foregroundColor(.gray2)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorSection(message: String) -> some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 48))
+                .foregroundColor(.gray3)
+            Text("오류가 발생했어요")
+                .Body1()
+                .foregroundColor(.gray2)
+            Text(message)
+                .Body2()
+                .foregroundColor(.gray3)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptySearchSection: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "person.crop.circle.badge.magnifyingglass")
+                .font(.system(size: 48))
+                .foregroundColor(.gray3)
+            Text("친구를 검색해 보세요")
+                .Body1()
+                .foregroundColor(.gray2)
+            Text("닉네임을 입력하고 검색을 눌러보세요")
+                .Body2()
+                .foregroundColor(.gray3)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var noResultsSection: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "person.fill.questionmark")
+                .font(.system(size: 48))
+                .foregroundColor(.gray3)
+            Text("검색 결과가 없어요")
+                .Body1()
+                .foregroundColor(.gray2)
+            Text("다른 닉네임으로 다시 시도해 보세요")
+                .Body2()
+                .foregroundColor(.gray3)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var searchResultsList: some View {
+        ScrollView(showsIndicators: false) {
+            LazyVStack(spacing: 0) {
+                ForEach(store.state.results) { item in
+                    Button {
+                        store.send(.rowTapped(item))
+                        isSearching = false
+                    } label: {
+                        FriendRow(item: item)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.bottom, 100)
+        }
+    }
 }
 
-// MARK: - Search Bar
 private struct FriendIDSearchBar: View {
     @Binding var text: String
     @FocusState var isFocused: Bool
@@ -373,7 +445,6 @@ private struct FriendIDSearchBar: View {
     }
 }
 
-// MARK: - 친구 선택 카드
 private struct FriendSelectedCard: View {
     let item: FriendSearchItem
     let isLoading: Bool
@@ -443,37 +514,37 @@ private struct FriendSelectedCard: View {
     }
 }
 
-// MARK: - Result Row
 private struct FriendRow: View {
     let item: FriendSearchItem
 
     var body: some View {
         HStack(spacing: 12) {
             ProfileImageView(url: item.profileImageURL)
-                .frame(width: 48, height: 48)
+                .frame(width: 52, height: 52)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(item.nickname)
-                    .font(.body.weight(.semibold))
+                    .H2()
+                    .foregroundColor(.gray1)
                 Text(item.id)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                    .Body2()
+                    .foregroundColor(.gray2)
             }
 
             Spacer()
         }
-        .padding(.vertical, 6)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
     }
 }
 
-// MARK: - Image View (Kingfisher + KFHeaders)
 private struct ProfileImageView: View {
     let url: URL?
 
     var body: some View {
         if let url {
             KFImage(url)
-                .requestModifier(KFHeaders.modifier) // 인증/공통 헤더
+                .requestModifier(KFHeaders.modifier)
                 .placeholder { placeholder }
                 .cacheOriginalImage()
                 .fade(duration: 0.2)
@@ -488,9 +559,9 @@ private struct ProfileImageView: View {
 
     private var placeholder: some View {
         ZStack {
-            Circle().fill(Color.gray.opacity(0.2))
+            Circle().fill(Color.gray3)
             Image(systemName: "person.fill")
-                .foregroundStyle(.secondary)
+                .foregroundColor(.white)
         }
     }
 }

--- a/Moda/Feature/Friend/Detail/ProfileDetailView.swift
+++ b/Moda/Feature/Friend/Detail/ProfileDetailView.swift
@@ -10,7 +10,6 @@ import Observation
 import Kingfisher
 import Combine
 
-// MARK: - Model
 private enum ProfileTab: String, CaseIterable, Identifiable {
     case myItems
     case likeItems
@@ -25,7 +24,6 @@ private enum ProfileTab: String, CaseIterable, Identifiable {
     }
 }
 
-// MARK: - State
 private struct ProfileDetailState {
     // 입력/환경
     var isCurrentUser: Bool = true
@@ -73,7 +71,6 @@ private struct ProfileDetailState {
     }
 }
 
-// MARK: - Intent
 private enum ProfileDetailIntent {
     case onAppear
     case selectTab(ProfileTab)
@@ -85,7 +82,6 @@ private enum ProfileDetailIntent {
     case toggleLike(String)
 }
 
-// MARK: - Store (@Observable)
 @MainActor
 @Observable
 private final class ProfileDetailStore {
@@ -131,7 +127,6 @@ private final class ProfileDetailStore {
         }
     }
 
-    // MARK: - Combine
     private func setupCombine() {
         likeSubject
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
@@ -143,7 +138,6 @@ private final class ProfileDetailStore {
             .store(in: &cancellables)
     }
 
-    // MARK: - Handlers
     private func handleOnAppear() {
         // 초기에는 사용자 게시글 로드
         if state.userPosts.isEmpty {
@@ -186,7 +180,6 @@ private final class ProfileDetailStore {
         }
     }
 
-    // MARK: - API Calls
     private func fetchUserPosts(refresh: Bool) async {
         if refresh {
             state.nextCursorUser = ""
@@ -270,7 +263,6 @@ private final class ProfileDetailStore {
         state.isLoading = false
     }
 
-    // MARK: - Like with Debouncing
     private func toggleLikeWithDebounce(postId: String) {
         // 현재 탭 기준으로 먼저 UI 반영
         updateLikeUI(postId: postId) { newState in
@@ -349,11 +341,10 @@ private final class ProfileDetailStore {
     }
 }
 
-// MARK: - View
 struct ProfileDetailView: View {
     @State private var store: ProfileDetailStore
+    @EnvironmentObject var navigator: AppNavigator
 
-    // FriendListView에서 전달받아 초기 상태 구성
     init(people: People, isCurrentUser: Bool) {
         let initial = ProfileDetailState(
             userId: people.id,
@@ -381,10 +372,27 @@ struct ProfileDetailView: View {
                             segment
                         }
 
-                        productGrid(itemWidth: itemWidth, spacing: spacing, horizontalPadding: horizontalPadding)
+                        ProductGridView(
+                            products: store.state.currentList,
+                            itemWidth: itemWidth,
+                            spacing: spacing,
+                            horizontalPadding: horizontalPadding,
+                            currentLocation: nil,
+                            isLoading: store.state.isLoading,
+                            emptyMessage: store.state.isCurrentUser && store.state.selectedTab == .likeItems ? "찜한 물건이 없어요" : "등록된 물건이 없어요",
+                            onLikeTapped: { postId in
+                                store.send(.toggleLike(postId))
+                            },
+                            onProductTapped: { postId in
+                                navigator.push(.productDetail(postId: postId))
+                            },
+                            onLoadMore: {
+                                store.send(.loadMore)
+                            }
+                        )
                     }
                     .padding(.top, 8)
-                    .padding(.bottom, 80) // 플로팅 버튼 영역 확보
+                    .padding(.bottom, 80)
                 }
                 .refreshable {
                     store.send(.refresh)
@@ -396,13 +404,24 @@ struct ProfileDetailView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
         .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    navigator.pop()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.gray1)
+                }
+            }
+
             if store.state.isCurrentUser {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("수정") {
                         store.send(.editTapped)
                     }
-                    .font(.body.weight(.semibold))
+                    .font(.custom("SUIT-Medium", size: 14))
+                    .foregroundColor(.gray1)
                 }
             }
         }
@@ -420,13 +439,12 @@ struct ProfileDetailView: View {
 
     private var header: some View {
         VStack(spacing: 10) {
-            // 프로필 이미지
             Group {
                 if let url = store.state.profileImageURL {
                     KFImage(url)
                         .requestModifier(KFHeaders.modifier)
                         .placeholder {
-                            Circle().fill(Color.gray.opacity(0.2))
+                            Circle().fill(Color.gray3)
                         }
                         .cacheOriginalImage()
                         .fade(duration: 0.2)
@@ -436,16 +454,17 @@ struct ProfileDetailView: View {
                         .clipShape(Circle())
                 } else {
                     ZStack {
-                        Circle().fill(Color.gray.opacity(0.2))
+                        Circle().fill(Color.gray3)
                         Image(systemName: "person.fill")
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.white)
                     }
                     .frame(width: 72, height: 72)
                 }
             }
 
             Text(store.state.nickname)
-                .font(.headline.weight(.semibold))
+                .H2()
+                .foregroundColor(.gray1)
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 16)
@@ -465,78 +484,28 @@ struct ProfileDetailView: View {
         .padding(.horizontal, 16)
     }
 
-    @ViewBuilder
-    private func productGrid(itemWidth: CGFloat, spacing: CGFloat, horizontalPadding: CGFloat) -> some View {
-        let items = store.state.currentList
-
-        if items.isEmpty && store.state.isLoading {
-            ProgressView()
-                .frame(maxWidth: .infinity)
-                .padding(.top, 50)
-        } else if items.isEmpty {
-            Text(store.state.isCurrentUser && store.state.selectedTab == .likeItems ? "찜한 물건이 없어요" : "등록된 물건이 없어요")
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, alignment: .center)
-                .padding(.top, 40)
-        } else {
-            HStack(alignment: .top, spacing: spacing) {
-                // 왼쪽 열
-                VStack(spacing: 12) {
-                    ForEach(Array(items.enumerated().filter { $0.offset % 2 == 0 }), id: \.element.id) { index, product in
-                        PostCardView(
-                            product: product,
-                            itemWidth: itemWidth,
-                            currentLocation: nil,
-                            onLikeTapped: { store.send(.toggleLike(product.id)) }
-                        )
-                        .onAppear {
-                            if index >= items.count - 4 {
-                                store.send(.loadMore)
-                            }
-                        }
-                    }
-                }
-                .frame(width: itemWidth)
-
-                // 오른쪽 열
-                VStack(spacing: 12) {
-                    ForEach(Array(items.enumerated().filter { $0.offset % 2 == 1 }), id: \.element.id) { index, product in
-                        PostCardView(
-                            product: product,
-                            itemWidth: itemWidth,
-                            currentLocation: nil,
-                            onLikeTapped: { store.send(.toggleLike(product.id)) }
-                        )
-                        .onAppear {
-                            if index >= items.count - 4 {
-                                store.send(.loadMore)
-                            }
-                        }
-                    }
-                }
-                .frame(width: itemWidth)
-            }
-            .padding(.horizontal, horizontalPadding)
-        }
-    }
 }
 
-// MARK: - Subviews
 private struct FloatingUploadButton: View {
     let title: String
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
-            Text(title)
-                .font(.headline.weight(.semibold))
-                .foregroundStyle(.white)
-                .padding(.horizontal, 16)
-                .frame(height: 48)
-                .background(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(Color.orange)
-                )
+            HStack(spacing: 8) {
+                Image(systemName: "plus")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundColor(.white)
+                Text(title)
+                    .H2()
+                    .foregroundColor(.white)
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 14)
+            .background(
+                Capsule()
+                    .fill(Color.blue1)
+            )
         }
         .buttonStyle(.plain)
         .shadow(color: .black.opacity(0.15), radius: 6, x: 0, y: 3)

--- a/Moda/Feature/Friend/List/FriendListView.swift
+++ b/Moda/Feature/Friend/List/FriendListView.swift
@@ -114,69 +114,24 @@ final class FriendListStore {
 }
 
 
-// MARK: - Mainview
 struct FriendListView: View {
     @State private var store = FriendListStore()
-    // 네비게이션
     @EnvironmentObject var navigator: AppNavigator
 
     var body: some View {
-        List {
-            // 내 프로필 섹션
-            Section {
-                if let my = store.myPeople {
-                    MyProfileHeader(people: my)
-                        .onTapGesture {
-                            // 내 프로필 상세
-                            navigator.push(.profileDetail(people: my, isCurrentUser: true))
-                        }
-                        .listRowSeparator(.hidden)
-                        .listRowBackground(Color.clear)
-                        .listRowInsets(.init(top: 8, leading: 16, bottom: 8, trailing: 16))
-                } else {
-                    // 로딩 중/미표시 상태용 플레이스홀더
-                    MyProfilePlaceholder()
-                        .listRowSeparator(.hidden)
-                        .listRowBackground(Color.clear)
-                        .listRowInsets(.init(top: 8, leading: 16, bottom: 8, trailing: 16))
-                }
-            }
+        ZStack {
+            Color.white
+                .ignoresSafeArea()
 
-            // 친구 섹션(맞팔만)
-            Section {
-                let friendPeople = store.friendPeople
-                if friendPeople.isEmpty {
-                    EmptyFriendsView()
-                } else {
-                    ForEach(friendPeople) { person in
-                        FriendRow(people: person)
-                            .onTapGesture {
-                                // 친구 프로필 상세 (친구 정보 전달)
-                                navigator.push(.profileDetail(people: person, isCurrentUser: false))
-                            }
+            VStack(spacing: 0) {
+                headerSection
+
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: 0) {
+                        myProfileSection
+                        friendListSection
                     }
-                }
-            } header: {
-                Text("친구 \(store.friendPeople.count)")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .listStyle(.plain)
-        .navigationTitle("친구")
-        .navigationBarTitleDisplayMode(.large)
-        .toolbar {
-            ToolbarItemGroup(placement: .navigationBarTrailing) {
-                Button {
-                    navigator.push(.friendSearch(friends: store.friendPeople))
-                } label: {
-                    Image(systemName: "magnifyingglass")
-                }
-
-                Button {
-                    navigator.push(.friendAdd)
-                } label: {
-                    Image(systemName: "person.badge.plus")
+                    .padding(.bottom, 100)
                 }
             }
         }
@@ -202,96 +157,190 @@ struct FriendListView: View {
             }
         )
     }
-}
 
-// MARK: - Subviews
-private struct MyProfileHeader: View {
-    let people: People
+    private var headerSection: some View {
+        HStack(spacing: 20) {
+            Text("친구")
+                .H1()
+                .foregroundColor(.gray1)
 
-    var body: some View {
-        HStack(spacing: 14) {
-            ProfileImageView(people: people)
-                .frame(width: 56, height: 56)
+            Spacer()
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(people.name)
-                    .font(.title3.weight(.semibold))
+            Button {
+                navigator.push(.friendSearch(friends: store.friendPeople))
+            } label: {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.gray1)
+            }
 
-                if let msg = people.statusMessage, !msg.isEmpty {
-                    Text(msg)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+            Button {
+                navigator.push(.friendAdd)
+            } label: {
+                Image(systemName: "person.badge.plus")
+                    .foregroundColor(.gray1)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color.white)
+    }
+
+    private var myProfileSection: some View {
+        VStack(spacing: 0) {
+            if let my = store.myPeople {
+                MyProfileCell(people: my) {
+                    navigator.push(.profileDetail(people: my, isCurrentUser: true))
+                }
+            } else {
+                MyProfilePlaceholder()
+            }
+        }
+    }
+
+    private var friendListSection: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("친구 \(store.friendPeople.count)")
+                    .Body2()
+                    .foregroundColor(.gray2)
+
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+
+            let friendPeople = store.friendPeople
+            if friendPeople.isEmpty {
+                emptyFriendsSection
+            } else {
+                LazyVStack(spacing: 0) {
+                    ForEach(friendPeople) { person in
+                        FriendCell(people: person) {
+                            navigator.push(.profileDetail(people: person, isCurrentUser: false))
+                        }
+                    }
                 }
             }
+        }
+    }
+
+    private var emptyFriendsSection: some View {
+        VStack(spacing: 12) {
+            Spacer()
+
+            Image(systemName: "person.2")
+                .font(.system(size: 48))
+                .foregroundColor(.gray3)
+
+            Text("아직 친구가 없어요")
+                .Body1()
+                .foregroundColor(.gray2)
 
             Spacer()
         }
-        .padding(.vertical, 6)
-        .contentShape(Rectangle())
+        .frame(maxWidth: .infinity)
+        .frame(height: UIScreen.main.bounds.height - 300)
+    }
+}
+
+private struct MyProfileCell: View {
+    let people: People
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                profileImageSection
+                contentSection
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var profileImageSection: some View {
+        ProfileImageView(people: people)
+            .frame(width: 52, height: 52)
+    }
+
+    private var contentSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(people.name)
+                .H2()
+                .foregroundColor(.gray1)
+
+            if let msg = people.statusMessage, !msg.isEmpty {
+                Text(msg)
+                    .Body2()
+                    .foregroundColor(.gray2)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
 private struct MyProfilePlaceholder: View {
     var body: some View {
-        HStack(spacing: 14) {
+        HStack(spacing: 12) {
             Circle()
-                .fill(Color.gray.opacity(0.2))
-                .frame(width: 56, height: 56)
+                .fill(Color.gray3)
+                .frame(width: 52, height: 52)
 
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 4) {
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(Color.gray.opacity(0.2))
-                    .frame(width: 120, height: 16)
+                    .fill(Color.gray3)
+                    .frame(width: 120, height: 18)
 
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(Color.gray.opacity(0.2))
+                    .fill(Color.gray3)
                     .frame(width: 180, height: 14)
             }
+
             Spacer()
         }
-        .padding(.vertical, 6)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
         .redacted(reason: .placeholder)
     }
 }
 
-private struct FriendRow: View {
+private struct FriendCell: View {
     let people: People
+    let onTap: () -> Void
 
     var body: some View {
-        HStack(spacing: 12) {
-            ProfileImageView(people: people)
-                .frame(width: 48, height: 48)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(people.name)
-                    .font(.body.weight(.semibold))
-
-                if let msg = people.statusMessage, !msg.isEmpty {
-                    Text(msg)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                profileImageSection
+                contentSection
             }
-
-            Spacer()
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
         }
-        .padding(.vertical, 6)
-        .contentShape(Rectangle())
+        .buttonStyle(.plain)
     }
-}
 
-private struct EmptyFriendsView: View {
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("아직 친구가 없습니다")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+    private var profileImageSection: some View {
+        ProfileImageView(people: people)
+            .frame(width: 52, height: 52)
+    }
+
+    private var contentSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(people.name)
+                .H2()
+                .foregroundColor(.gray1)
+
+            if let msg = people.statusMessage, !msg.isEmpty {
+                Text(msg)
+                    .Body2()
+                    .foregroundColor(.gray2)
+                    .lineLimit(1)
+            }
         }
-        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Moda/Feature/Friend/Search/FriendSearchView.swift
+++ b/Moda/Feature/Friend/Search/FriendSearchView.swift
@@ -9,19 +9,16 @@ import SwiftUI
 import Observation
 import Kingfisher
 
-// MARK: - State
 private struct FriendSearchState {
     var query: String = ""
     var results: [People] = []
 }
 
-// MARK: - Action
 private enum FriendSearchAction {
     case queryChanged(String)
     case clearTapped
 }
 
-// MARK: - Store (@Observable)
 @MainActor
 @Observable
 private final class FriendSearchStore {
@@ -43,7 +40,6 @@ private final class FriendSearchStore {
         }
     }
 
-    // MARK: - Handlers
     private func handleClearTapped() {
         state.query = ""
         state.results = []
@@ -59,7 +55,6 @@ private final class FriendSearchStore {
         }
     }
 
-    // MARK: - Filtering
     private func applyFilter() {
         let trimmed = state.query.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
@@ -72,9 +67,7 @@ private final class FriendSearchStore {
     }
 }
 
-// MARK: - View
 struct FriendSearchView: View {
-    // @Observable Store는 @State로 보유
     @State private var store: FriendSearchStore
     @FocusState private var isSearching: Bool
     @Environment(\.dismiss) private var dismiss
@@ -84,64 +77,91 @@ struct FriendSearchView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            // 상단 검색 영역 (서치바)
-            HStack(spacing: 8) {
-                FriendSearchBar(
-                    text: Binding(
-                        get: { store.state.query },
-                        set: { store.send(.queryChanged($0)) }
-                    ),
-                    isFocused: _isSearching,
-                    onClear: { store.send(.clearTapped) }
-                )
-                .padding(.vertical, 8)
+        ZStack {
+            Color.white
+                .ignoresSafeArea()
 
-                Button("취소") {
-                    store.send(.clearTapped)
-                    isSearching = false
-                    dismiss()
+            VStack(spacing: 0) {
+                searchBarSection
+
+                if store.state.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Spacer()
+                } else {
+                    searchResultsSection
                 }
-                .foregroundStyle(.black)
             }
-            .padding(.horizontal, 12)
-            .background(.ultraThinMaterial)
-
-            // 검색 결과 표시
-            if store.state.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                Spacer()
-            } else {
-                List {
-                    Section {
-                        if store.state.results.isEmpty {
-                            EmptyStateView(keyword: store.state.query)
-                                .listRowSeparator(.hidden)
-                                .listRowBackground(Color.clear)
-                        } else {
-                            ForEach(store.state.results) { person in
-                                FriendRowView(people: person)
-                            }
-                        }
-                    } header: {
-                        Text("검색 결과 \(store.state.results.count)")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.gray1)
                 }
-                .listStyle(.plain)
             }
         }
         .task {
-            // 진입 시 키보드 바로 올리기 (살짝 지연)
             try? await Task.sleep(for: .milliseconds(250))
             await MainActor.run {
                 isSearching = true
             }
         }
     }
+
+    private var searchBarSection: some View {
+        HStack(spacing: 8) {
+            FriendSearchBar(
+                text: Binding(
+                    get: { store.state.query },
+                    set: { store.send(.queryChanged($0)) }
+                ),
+                isFocused: _isSearching,
+                onClear: { store.send(.clearTapped) }
+            )
+            .padding(.vertical, 8)
+
+            Button("취소") {
+                store.send(.clearTapped)
+                isSearching = false
+                dismiss()
+            }
+            .font(.custom("SUIT-Medium", size: 14))
+            .foregroundColor(.gray1)
+        }
+        .padding(.horizontal, 16)
+        .background(Color.white)
+    }
+
+    private var searchResultsSection: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 0) {
+                HStack {
+                    Text("검색 결과 \(store.state.results.count)")
+                        .Body2()
+                        .foregroundColor(.gray2)
+
+                    Spacer()
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+
+                if store.state.results.isEmpty {
+                    EmptyStateView(keyword: store.state.query)
+                } else {
+                    LazyVStack(spacing: 0) {
+                        ForEach(store.state.results) { person in
+                            FriendRowView(people: person)
+                        }
+                    }
+                }
+            }
+            .padding(.bottom, 100)
+        }
+    }
 }
 
-// MARK: - Search Field
 private struct FriendSearchBar: View {
     @Binding var text: String
     @FocusState var isFocused: Bool
@@ -176,31 +196,31 @@ private struct FriendSearchBar: View {
     }
 }
 
-// MARK: - Row & Subviews
 private struct FriendRowView: View {
     let people: People
 
     var body: some View {
         HStack(spacing: 12) {
             ProfileImageView(people: people)
-                .frame(width: 48, height: 48)
+                .frame(width: 52, height: 52)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(people.name)
-                    .font(.body.weight(.semibold))
+                    .H2()
+                    .foregroundColor(.gray1)
 
                 if let msg = people.statusMessage, !msg.isEmpty {
                     Text(msg)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .Body2()
+                        .foregroundColor(.gray2)
                         .lineLimit(1)
-                        .truncationMode(.tail)
                 }
             }
 
             Spacer()
         }
-        .padding(.vertical, 6)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
         .contentShape(Rectangle())
     }
 }
@@ -220,17 +240,17 @@ private struct ProfileImageView: View {
                 .scaledToFill()
                 .clipShape(Circle())
         } else {
-            // 이미지 불러와지지 않을때 임시 이미지.
             ZStack {
-                Circle().fill(Color.gray.opacity(0.2))
+                Circle().fill(Color.gray3)
                 Image(systemName: "person.fill")
+                    .foregroundColor(.white)
             }
             .clipShape(Circle())
         }
     }
 
     private var placeholder: some View {
-        Circle().fill(Color.gray.opacity(0.2))
+        Circle().fill(Color.gray3)
     }
 }
 
@@ -238,20 +258,27 @@ private struct EmptyStateView: View {
     let keyword: String
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 12) {
+            Spacer()
+
             Image(systemName: "person.2.slash")
-                .font(.system(size: 36, weight: .regular))
-                .foregroundStyle(.secondary)
+                .font(.system(size: 48))
+                .foregroundColor(.gray3)
+
             Text("검색 결과가 없어요")
-                .font(.headline)
+                .Body1()
+                .foregroundColor(.gray2)
+
             if !keyword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                Text("“\(keyword)”에 대한 친구를 찾지 못했어요.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                Text("\"\(keyword)\"에 대한 친구를 찾지 못했어요")
+                    .Body2()
+                    .foregroundColor(.gray3)
             }
+
+            Spacer()
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 32)
+        .frame(height: UIScreen.main.bounds.height - 300)
     }
 }
 

--- a/Moda/Feature/Home/Components/ProductGridView.swift
+++ b/Moda/Feature/Home/Components/ProductGridView.swift
@@ -1,0 +1,100 @@
+//
+//  ProductGridView.swift
+//  Moda
+//
+//  Created by 금가경 on 11/25/24.
+//
+
+import SwiftUI
+import CoreLocation
+
+struct ProductGridView: View {
+    let products: [PostCard]
+    let itemWidth: CGFloat
+    let spacing: CGFloat
+    let horizontalPadding: CGFloat
+    let currentLocation: CLLocationCoordinate2D?
+    let isLoading: Bool
+    let emptyMessage: String
+    let onLikeTapped: (String) -> Void
+    let onProductTapped: ((String) -> Void)?
+    let onLoadMore: (() -> Void)?
+
+    var body: some View {
+        if products.isEmpty && isLoading {
+            shimmerGrid
+        } else if products.isEmpty {
+            Text(emptyMessage)
+                .Body1()
+                .foregroundColor(.gray2)
+                .frame(maxWidth: .infinity)
+                .padding(.top, 50)
+        } else {
+            HStack(alignment: .top, spacing: spacing) {
+                leftColumn
+                rightColumn
+            }
+            .padding(.horizontal, horizontalPadding)
+            .animation(.none, value: products.count)
+        }
+    }
+
+    private var shimmerGrid: some View {
+        HStack(alignment: .top, spacing: spacing) {
+            VStack(spacing: 12) {
+                ForEach(0..<3, id: \.self) { _ in
+                    PostCardShimmerView(itemWidth: itemWidth)
+                }
+            }
+            .frame(width: itemWidth)
+
+            VStack(spacing: 12) {
+                ForEach(0..<3, id: \.self) { _ in
+                    PostCardShimmerView(itemWidth: itemWidth)
+                }
+            }
+            .frame(width: itemWidth)
+        }
+        .padding(.horizontal, horizontalPadding)
+    }
+
+    private var leftColumn: some View {
+        VStack(spacing: 12) {
+            ForEach(Array(products.enumerated().filter { $0.offset % 2 == 0 }), id: \.element.id) { index, product in
+                PostCardView(
+                    product: product,
+                    itemWidth: itemWidth,
+                    currentLocation: currentLocation,
+                    onLikeTapped: { onLikeTapped(product.id) },
+                    onTapped: { onProductTapped?(product.id) }
+                )
+                .onAppear {
+                    if index >= products.count - 4 {
+                        onLoadMore?()
+                    }
+                }
+            }
+        }
+        .frame(width: itemWidth)
+    }
+
+    private var rightColumn: some View {
+        VStack(spacing: 12) {
+            ForEach(Array(products.enumerated().filter { $0.offset % 2 == 1 }), id: \.element.id) { index, product in
+                PostCardView(
+                    product: product,
+                    itemWidth: itemWidth,
+                    currentLocation: currentLocation,
+                    onLikeTapped: { onLikeTapped(product.id) },
+                    onTapped: { onProductTapped?(product.id) }
+                )
+                .onAppear {
+                    if index >= products.count - 4 {
+                        onLoadMore?()
+                    }
+                }
+            }
+        }
+        .frame(width: itemWidth)
+    }
+}

--- a/Moda/Feature/Home/Feed/FeedComponents.swift
+++ b/Moda/Feature/Home/Feed/FeedComponents.swift
@@ -18,13 +18,13 @@ struct QuickActionButton: View {
     private var iconColor: Color {
         switch icon {
         case "arrow.up.circle.fill":
-            return Color.green1
+            return .green1
         case "heart.fill":
-            return Color.pink1
+            return .pink1
         case "clock.fill":
-            return Color.blue1
+            return .blue1
         default:
-            return Color.gray1
+            return .gray1
         }
     }
 
@@ -43,7 +43,7 @@ struct QuickActionButton: View {
             .padding(.vertical, 10)
             .background(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color.white.opacity(0.6))
+                    .fill(.white.opacity(0.6))
             )
         }
     }
@@ -56,14 +56,6 @@ struct PostCardView: View {
     let onLikeTapped: () -> Void
     let onTapped: () -> Void
 
-    init(product: PostCard, itemWidth: CGFloat, currentLocation: CLLocationCoordinate2D?, onLikeTapped: @escaping () -> Void, onTapped: @escaping () -> Void = {}) {
-        self.product = product
-        self.itemWidth = itemWidth
-        self.currentLocation = currentLocation
-        self.onLikeTapped = onLikeTapped
-        self.onTapped = onTapped
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             imageSection
@@ -72,9 +64,7 @@ struct PostCardView: View {
         }
         .frame(width: itemWidth, alignment: .leading)
         .contentShape(Rectangle())
-        .onTapGesture {
-            onTapped()
-        }
+        .onTapGesture(perform: onTapped)
     }
 
     private var profileSection: some View {
@@ -107,7 +97,7 @@ struct PostCardView: View {
                 HStack(spacing: 4) {
                     Image(systemName: product.isLiked ? "heart.fill" : "heart")
                         .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(product.isLiked ? Color.pink1 : Color.gray1)
+                        .foregroundColor(product.isLiked ? .pink1 : .gray1)
 
                     Text("\(product.likeCount)")
                         .Body1()
@@ -132,7 +122,7 @@ struct PostCardView: View {
                     .cacheOriginalImage()
                     .fade(duration: 0.2)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .frame(width: itemWidth)
                     .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             } else {
@@ -151,26 +141,27 @@ struct PostCardView: View {
                 .lineLimit(2)
                 .fixedSize(horizontal: false, vertical: true)
 
-            HStack(spacing: 4) {
-                if let distance = product.formattedDistance(from: currentLocation.map { ($0.latitude, $0.longitude) }) {
-                    Text(distance)
-                        .Body2()
-                        .foregroundColor(.gray2)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    if let distance = product.formattedDistance(from: currentLocation.map { ($0.latitude, $0.longitude) }) {
+                        Text(distance)
+                            .Body2()
+                            .foregroundColor(.gray2)
+                            .lineLimit(1)
 
-                    Text("·")
-                        .Body2()
-                        .foregroundColor(.gray2)
-                }
+                        Text("·")
+                            .Body2()
+                            .foregroundColor(.gray2)
+                    }
 
-                if let location = product.formattedLocation {
-                    Text(location)
-                        .Body2()
-                        .foregroundColor(.gray2)
-                        .lineLimit(1)
+                    if let location = product.formattedLocation {
+                        Text(location)
+                            .Body2()
+                            .foregroundColor(.gray2)
+                            .lineLimit(1)
+                    }
 
-                    Text("·")
-                        .Body2()
-                        .foregroundColor(.gray2)
+                    Spacer(minLength: 0)
                 }
 
                 Text(product.formattedDate)

--- a/Moda/Feature/Home/Feed/FeedState.swift
+++ b/Moda/Feature/Home/Feed/FeedState.swift
@@ -22,7 +22,7 @@ struct FeedViewState {
 
     // Pagination
     var nextCursor: String = ""
-    var isLoading: Bool = false
+    var isLoading: Bool = true
     var hasMoreData: Bool = true
 
     // Location
@@ -31,12 +31,20 @@ struct FeedViewState {
     // Error
     var errorMessage: String?
 
-    // 검색 결과 또는 전체 목록 반환
+    // 검색 결과 또는 카테고리 필터링된 목록 반환
     var displayProducts: [PostCard] {
-        if searchText.isEmpty {
-            return products
-        } else {
+        if !searchText.isEmpty {
             return filteredProducts
+        }
+
+        // 카테고리 필터링
+        switch selectedCategory {
+        case "중고거래":
+            return products.filter { ($0.price ?? 0) > 0 }
+        case "나눔":
+            return products.filter { ($0.price ?? 0) == 0 }
+        default: // "전체"
+            return products
         }
     }
 }

--- a/Moda/Feature/Home/Feed/FeedStore.swift
+++ b/Moda/Feature/Home/Feed/FeedStore.swift
@@ -70,7 +70,6 @@ final class FeedViewStore: NSObject, ObservableObject {
 
         case .selectCategory(let category):
             state.selectedCategory = category
-            Task { await loadPosts(refresh: true) }
 
         case .toggleLike(let postId):
             toggleLikeWithDebounce(postId: postId)
@@ -140,15 +139,6 @@ final class FeedViewStore: NSObject, ObservableObject {
 
             // 최신순 정렬
             newProducts.sort { $0.createdAt > $1.createdAt }
-
-            switch state.selectedCategory {
-            case "중고거래":
-                newProducts = newProducts.filter { ($0.price ?? 0) > 0 }
-            case "나눔":
-                newProducts = newProducts.filter { ($0.price ?? 0) == 0 }
-            default:
-                break // 전체는 필터링 없음
-            }
 
             if refresh {
                 state.products = newProducts

--- a/Moda/Feature/Home/Feed/FeedView.swift
+++ b/Moda/Feature/Home/Feed/FeedView.swift
@@ -27,8 +27,27 @@ struct FeedView: View {
 //                    userInfoCard
                     ScrollView(showsIndicators: false) {
                         VStack(spacing: 20) {
-                            productSectionView(itemWidth: itemWidth, spacing: spacing, horizontalPadding: horizontalPadding)
-                            
+                            ProductGridView(
+                                products: store.state.displayProducts,
+                                itemWidth: itemWidth,
+                                spacing: spacing,
+                                horizontalPadding: horizontalPadding,
+                                currentLocation: store.state.currentLocation,
+                                isLoading: store.state.isLoading && store.state.products.isEmpty,
+                                emptyMessage: store.state.isSearching ? "검색 결과가 없습니다." : "게시글이 없습니다.",
+                                onLikeTapped: { postId in
+                                    store.send(.toggleLike(postId))
+                                },
+                                onProductTapped: { postId in
+                                    navigator.push(.productDetail(postId: postId))
+                                },
+                                onLoadMore: {
+                                    if !store.state.isSearching {
+                                        store.send(.loadMore)
+                                    }
+                                }
+                            )
+
                             if store.state.isLoading && !store.state.products.isEmpty {
                                 ProgressView()
                                     .padding()
@@ -161,72 +180,6 @@ struct FeedView: View {
         .padding(.horizontal, 16)
     }
      */
-
-    @ViewBuilder
-    private func productSectionView(itemWidth: CGFloat, spacing: CGFloat, horizontalPadding: CGFloat) -> some View {
-        let products = store.state.displayProducts
-
-        if products.isEmpty && store.state.isLoading {
-            ProgressView()
-                .frame(maxWidth: .infinity)
-                .padding(.top, 50)
-        } else if products.isEmpty {
-            Text(store.state.isSearching ? "검색 결과가 없습니다." : "게시글이 없습니다.")
-                .Body1()
-                .foregroundColor(.gray2)
-                .frame(maxWidth: .infinity)
-                .padding(.top, 50)
-        } else {
-            HStack(alignment: .top, spacing: spacing) {
-                // 왼쪽 열
-                VStack(spacing: 12) {
-                    ForEach(Array(products.enumerated().filter { $0.offset % 2 == 0 }), id: \.element.id) { index, product in
-                        PostCardView(
-                            product: product,
-                            itemWidth: itemWidth,
-                            currentLocation: store.state.currentLocation,
-                            onLikeTapped: {
-                                store.send(.toggleLike(product.id))
-                            },
-                            onTapped: {
-                                navigator.push(.productDetail(postId: product.id))
-                            }
-                        )
-                        .onAppear {
-                            if index >= products.count - 4 && !store.state.isSearching {
-                                store.send(.loadMore)
-                            }
-                        }
-                    }
-                }
-                .frame(width: itemWidth)
-
-                // 오른쪽 열
-                VStack(spacing: 12) {
-                    ForEach(Array(products.enumerated().filter { $0.offset % 2 == 1 }), id: \.element.id) { index, product in
-                        PostCardView(
-                            product: product,
-                            itemWidth: itemWidth,
-                            currentLocation: store.state.currentLocation,
-                            onLikeTapped: {
-                                store.send(.toggleLike(product.id))
-                            },
-                            onTapped: {
-                                navigator.push(.productDetail(postId: product.id))
-                            }
-                        )
-                        .onAppear {
-                            if index >= products.count - 4 && !store.state.isSearching {
-                                store.send(.loadMore)
-                            }
-                        }
-                    }
-                }
-                .frame(width: itemWidth)
-            }
-            .padding(.horizontal, horizontalPadding)
-        }
-    }
 
     private var uploadButton: some View {
         VStack {


### PR DESCRIPTION
# Pull requests

## 작업한 브랜치
> 관련된 이슈 번호를 적어주세요.  
> ex - #0
- #60 

## 작업한 내용
> 이번 PR에서 수행한 주요 작업 내용을 간략히 작성해주세요.
- 친구 탭 레이아웃을 수정했습니다
- 친구의 판매목록이 피드뷰의 2열 구조를 재사용하도록 만들었습니다. 

## 참고 사항
> 이외 참고할 만한 내용이 있다면 작성해주세요.
-
> 
## 스크린샷
> 시각적으로 확인이 필요한 경우 첨부해주세요.

|뷰 이름|뷰 이름|
|:--:|:--:|
|<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-11-25 at 01 40 20" src="https://github.com/user-attachments/assets/29a15f34-aeeb-4263-b4fb-09ad82cd594d" />|<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-11-25 at 01 40 07" src="https://github.com/user-attachments/assets/bdbc012a-92c9-41d4-a5ba-96d27651faae" />|
|뷰 이름|뷰 이름|
|<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-11-25 at 01 40 10" src="https://github.com/user-attachments/assets/49653c7c-c0d5-45d9-8b8a-0d71544dd18a" />|<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-11-25 at 01 40 13" src="https://github.com/user-attachments/assets/6b1ab325-4ca8-4907-bc08-9ed143352c9c" />|
