### PR TITLE
77 찜목록의 동영상 상품에 동영상 썸네일 표시되도록 수정

### DIFF
--- a/Moda/Core/Navigation/NavigationDestination.swift
+++ b/Moda/Core/Navigation/NavigationDestination.swift
@@ -81,6 +81,9 @@ enum NavigationDestination: Hashable {
     /// 상품 상세 화면
     case productDetail(postId: String)
 
+    /// 찜 목록 화면
+    case likedPosts
+
     // MARK: FriendTab
     /// 친구 검색 화면
     case friendSearch(friends: [People])
@@ -123,6 +126,8 @@ extension NavigationDestination {
             ProductUploadView(editMode: editMode, postId: postId)
         case .productDetail(let postId):
             ProductDetailView(postId: postId)
+        case .likedPosts:
+            LikedPostsView()
 
         //MARK: FriendTab
         case .friendSearch(let friends):

--- a/Moda/Feature/Setting/Likes/LikedPostsState.swift
+++ b/Moda/Feature/Setting/Likes/LikedPostsState.swift
@@ -21,6 +21,7 @@ struct LikedPost: Identifiable {
     let title: String
     let price: Int
     let mediaURL: URL?
+    let mediaPath: String? // 원본 파일 경로 (확장자 확인용)
     let profileImageURL: URL?
     let nickname: String
     var isLiked: Bool

--- a/Moda/Feature/Setting/Likes/LikedPostsStore.swift
+++ b/Moda/Feature/Setting/Likes/LikedPostsStore.swift
@@ -57,8 +57,9 @@ final class LikedPostsStore {
                 )
 
                 let newPosts = response.data.map { dto -> LikedPost in
+                    let firstFile = dto.files.first
                     let mediaURL: URL? = {
-                        guard let firstFile = dto.files.first else { return nil }
+                        guard let firstFile = firstFile else { return nil }
                         return URL(string: NetworkConfig.baseURL + "/v1/" + firstFile)
                     }()
 
@@ -75,6 +76,7 @@ final class LikedPostsStore {
                         title: dto.title,
                         price: Int(dto.price ?? 0),
                         mediaURL: mediaURL,
+                        mediaPath: firstFile,
                         profileImageURL: profileImageURL,
                         nickname: dto.creator.nick,
                         isLiked: isLiked

--- a/Moda/Feature/Setting/Likes/LikedPostsView.swift
+++ b/Moda/Feature/Setting/Likes/LikedPostsView.swift
@@ -103,23 +103,33 @@ private struct LikedPostItemView: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            if let url = post.mediaURL {
-                KFImage(url)
-                    .requestModifier(KFHeaders.modifier)
-                    .placeholder {
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .fill(Color.gray5)
-                    }
-                    .cacheOriginalImage()
-                    .fade(duration: 0.2)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
+            ZStack {
+                if let mediaPath = post.mediaPath {
+                    MediaImageView(
+                        mediaURL: mediaPath,
+                        contentMode: .fill,
+                        placeholder: {
+                            AnyView(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .fill(Color.gray5)
+                            )
+                        }
+                    )
                     .frame(width: 80, height: 80)
                     .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-            } else {
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color.gray5)
-                    .frame(width: 80, height: 80)
+
+                    // 동영상인 경우 재생 아이콘 표시
+                    if mediaPath.isVideoFile {
+                        Image(systemName: "play.circle.fill")
+                            .font(.system(size: 24))
+                            .foregroundColor(.white)
+                            .shadow(color: .black.opacity(0.3), radius: 2)
+                    }
+                } else {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color.gray5)
+                        .frame(width: 80, height: 80)
+                }
             }
 
             VStack(alignment: .leading, spacing: 4) {

--- a/Moda/Feature/Setting/Likes/LikedPostsView.swift
+++ b/Moda/Feature/Setting/Likes/LikedPostsView.swift
@@ -9,56 +9,53 @@ import SwiftUI
 import Kingfisher
 
 struct LikedPostsView: View {
-    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var navigator: AppNavigator
     @State private var store = LikedPostsStore()
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Color.white.ignoresSafeArea()
+        ZStack {
+            Color.white.ignoresSafeArea()
 
-                if store.state.isLoading && store.state.posts.isEmpty {
-                    shimmerList
-                } else if store.state.posts.isEmpty {
-                    emptyStateView
-                } else {
-                    ScrollView {
-                        LazyVStack(spacing: 12) {
-                            ForEach(Array(store.state.posts.enumerated()), id: \.element.id) { index, post in
-                                LikedPostItemView(
-                                    post: post,
-                                    onLikeTapped: { store.send(.toggleLike(post.id)) },
-                                    onTapped: { store.send(.postTapped(post.id)) }
-                                )
-
+            if store.state.isLoading && store.state.posts.isEmpty {
+                shimmerList
+            } else if store.state.posts.isEmpty {
+                emptyStateView
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(Array(store.state.posts.enumerated()), id: \.element.id) { index, post in
+                            LikedPostItemView(
+                                post: post,
+                                onLikeTapped: { store.send(.toggleLike(post.id)) },
+                                onTapped: { navigator.push(.productDetail(postId: post.id)) }
+                            )
+                            .onAppear {
                                 if index >= store.state.posts.count - 4 {
-                                    Color.clear
-                                        .onAppear {
-                                            store.send(.loadMore)
-                                        }
+                                    store.send(.loadMore)
                                 }
                             }
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.top, 16)
-                        .padding(.bottom, 100)
                     }
-                    .refreshable {
-                        store.send(.refresh)
-                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 16)
+                    .padding(.bottom, 100)
+                }
+                .refreshable {
+                    store.send(.refresh)
                 }
             }
-            .navigationTitle("찜 목록")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 18))
-                            .foregroundColor(.gray1)
-                    }
+        }
+        .navigationTitle("찜 목록")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    navigator.pop()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 18))
+                        .foregroundColor(.gray1)
                 }
             }
         }
@@ -247,4 +244,5 @@ private struct LikedPostShimmerView: View {
 
 #Preview {
     LikedPostsView()
+        .environmentObject(AppNavigator.shared)
 }

--- a/Moda/Feature/Setting/SettingView.swift
+++ b/Moda/Feature/Setting/SettingView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 import Kingfisher
 
 struct SettingView: View {
+    @EnvironmentObject var navigator: AppNavigator
     @State private var store = SettingStore()
     @State private var showProfileEdit = false
-    @State private var showLikedPosts = false
     @State private var showLogoutAlert = false
 
     var body: some View {
@@ -40,9 +40,6 @@ struct SettingView: View {
             store.send(.refresh)
         }) {
             ProfileEditView()
-        }
-        .fullScreenCover(isPresented: $showLikedPosts) {
-            LikedPostsView()
         }
         .alert("로그아웃", isPresented: $showLogoutAlert) {
             Button("취소", role: .cancel) { }
@@ -128,7 +125,7 @@ struct SettingView: View {
                 title: "찜 목록",
                 subtitle: "좋아요한 게시글"
             ) {
-                showLikedPosts = true
+                navigator.push(.likedPosts)
             }
 
             ActionCard(
@@ -209,4 +206,5 @@ struct ActionCard: View {
 
 #Preview {
     SettingView()
+        .environmentObject(AppNavigator.shared)
 }

--- a/Moda/Feature/Setting/SettingView.swift
+++ b/Moda/Feature/Setting/SettingView.swift
@@ -133,7 +133,7 @@ struct SettingView: View {
 
             ActionCard(
                 icon: "clock.fill",
-                iconColor: .blue1,
+                iconColor: .green1,
                 title: "거래 내역",
                 subtitle: "나의 거래 기록"
             ) {
@@ -141,7 +141,7 @@ struct SettingView: View {
 
             ActionCard(
                 icon: "rectangle.portrait.and.arrow.right",
-                iconColor: .red,
+                iconColor: .blue1,
                 title: "로그아웃",
                 subtitle: "계정 로그아웃"
             ) {


### PR DESCRIPTION
# Pull requests

## 작업한 브랜치
> 관련된 이슈 번호를 적어주세요.  
> ex - #0
- #77 

## 작업한 내용
> 이번 PR에서 수행한 주요 작업 내용을 간략히 작성해주세요.
- 찜목록의 이미지뷰에 동영상 썸네일도 표시되도록 수정
- 셀 탭시 해당 게시글의 디테일뷰로 이동
- 찜목록을 네비게이션뷰로 변경

> 
## 스크린샷
> 시각적으로 확인이 필요한 경우 첨부해주세요.

|찜목록|
|:--:|
|<img width="300" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-11-27 at 17 50 06" src="https://github.com/user-attachments/assets/e0fe10e1-23d2-42b4-8b9d-75a81bc98558" />|
