### PR TITLE
79 pg 결제 거래내역 조회 api 연동 및 리스트 화면 구현

### DIFF
--- a/Moda.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Moda.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "335d2225b665e1a371e99ce2c0abf4a5a79bda920f973bf60934dac03692d932",
+  "originHash" : "5fa4ccdd982192b0fbd56a17748c86112cd1f39de8960479b967307fc3547ead",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -49,7 +49,7 @@
     {
       "identity" : "socket.io-client-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/socketio/socket.io-client-swift",
+      "location" : "https://github.com/socketio/socket.io-client-swift.git",
       "state" : {
         "branch" : "master",
         "revision" : "42da871d9369f290d6ec4930636c40672143905b"

--- a/Moda/Core/Navigation/NavigationDestination.swift
+++ b/Moda/Core/Navigation/NavigationDestination.swift
@@ -84,6 +84,9 @@ enum NavigationDestination: Hashable {
     /// 찜 목록 화면
     case likedPosts
 
+    /// 거래 내역 화면
+    case transactions
+
     // MARK: FriendTab
     /// 친구 검색 화면
     case friendSearch(friends: [People])
@@ -128,6 +131,8 @@ extension NavigationDestination {
             ProductDetailView(postId: postId)
         case .likedPosts:
             LikedPostsView()
+        case .transactions:
+            TransactionsView()
 
         //MARK: FriendTab
         case .friendSearch(let friends):

--- a/Moda/Core/Network/API/PostAPI.swift
+++ b/Moda/Core/Network/API/PostAPI.swift
@@ -229,4 +229,14 @@ final class PostAPI: PostAPIProtocol {
 
         return response
     }
+
+    func getPaymentList(next: String? = nil, limit: String? = nil) async throws -> PaymentListResponse {
+        let endpoint = PostRouter.getPaymentList(next: next, limit: limit)
+        let response = try await networkService.request(
+            endpoint: endpoint,
+            responseType: PaymentListResponse.self
+        )
+
+        return response
+    }
 }

--- a/Moda/Core/Network/Model/PaymentListResponse.swift
+++ b/Moda/Core/Network/Model/PaymentListResponse.swift
@@ -59,4 +59,10 @@ struct PaymentListResponse: Decodable {
         case data
         case nextCursor = "next_cursor"
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        data = try container.decode([PaymentTransaction].self, forKey: .data)
+        nextCursor = try container.decodeIfPresent(String.self, forKey: .nextCursor) ?? "0"
+    }
 }

--- a/Moda/Core/Network/Model/PaymentListResponse.swift
+++ b/Moda/Core/Network/Model/PaymentListResponse.swift
@@ -1,0 +1,62 @@
+//
+//  PaymentListResponse.swift
+//  Moda
+//
+//  Created by Suji Jang on 11/27/25.
+//
+
+import Foundation
+
+/// 거래 내역 모델
+struct PaymentTransaction: Decodable, Identifiable {
+    let id: String // buyerId_postId_merchantUid로 구성
+    let buyerId: String
+    let postId: String
+    let merchantUid: String
+    let productName: String
+    let price: Int
+    let paidAt: String
+    let post: PostSummary?
+
+    enum CodingKeys: String, CodingKey {
+        case buyerId = "buyer_id"
+        case postId = "post_id"
+        case merchantUid = "merchant_uid"
+        case productName
+        case price
+        case paidAt
+        case post
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        buyerId = try container.decode(String.self, forKey: .buyerId)
+        postId = try container.decode(String.self, forKey: .postId)
+        merchantUid = try container.decode(String.self, forKey: .merchantUid)
+        productName = try container.decode(String.self, forKey: .productName)
+        price = try container.decode(Int.self, forKey: .price)
+        paidAt = try container.decode(String.self, forKey: .paidAt)
+        post = try? container.decode(PostSummary.self, forKey: .post)
+
+        // ID 생성
+        id = "\(buyerId)_\(postId)_\(merchantUid)"
+    }
+}
+
+/// 게시글 요약 정보
+struct PostSummary: Decodable {
+    let title: String
+    let files: [String]
+    let creator: PostCreator
+}
+
+/// 거래 내역 리스트 응답
+struct PaymentListResponse: Decodable {
+    let data: [PaymentTransaction]
+    let nextCursor: String
+
+    enum CodingKeys: String, CodingKey {
+        case data
+        case nextCursor = "next_cursor"
+    }
+}

--- a/Moda/Core/Network/Router/PostRouter.swift
+++ b/Moda/Core/Network/Router/PostRouter.swift
@@ -94,6 +94,9 @@ enum PostRouter {
 
     /// 결제 검증
     case validatePayment(impUid: String, postId: String)
+
+    /// 거래 내역 조회
+    case getPaymentList(next: String?, limit: String?)
 }
 
 extension PostRouter: Endpoint {
@@ -105,6 +108,8 @@ extension PostRouter: Endpoint {
         switch self {
         case .validatePayment:
             return "/v1/payments/validation"
+        case .getPaymentList:
+            return "/v1/payments/me"
         default:
             let basePath = "/v1/posts"
             let subPath: String
@@ -294,6 +299,12 @@ extension PostRouter: Endpoint {
                 }
             }
             return items
+
+        case .getPaymentList(let next, let limit):
+            var items: [URLQueryItem] = []
+            if let next = next { items.append(URLQueryItem(name: "next", value: next)) }
+            if let limit = limit { items.append(URLQueryItem(name: "limit", value: limit)) }
+            return items.isEmpty ? nil : items
 
         default:
             return nil

--- a/Moda/Core/Protocol/PostAPIProtocol.swift
+++ b/Moda/Core/Protocol/PostAPIProtocol.swift
@@ -81,4 +81,7 @@ protocol PostAPIProtocol {
 
     /// 제목 검색
     func searchPosts(title: String, category: [String]?) async throws -> TitleSearchResponse
+
+    /// 거래 내역 조회
+    func getPaymentList(next: String?, limit: String?) async throws -> PaymentListResponse
 }

--- a/Moda/Feature/Product/Upload/Detail/ProductDetailView.swift
+++ b/Moda/Feature/Product/Upload/Detail/ProductDetailView.swift
@@ -16,6 +16,7 @@ extension Notification.Name {
     static let postLikeUpdated = Notification.Name("postLikeUpdated")
     static let postPaymentCompleted = Notification.Name("postPaymentCompleted")
     static let postUpdated = Notification.Name("postUpdated")
+    static let paymentResponse = Notification.Name("paymentResponse")
 }
 
 extension IamportPayment: @retroactive Identifiable {
@@ -125,7 +126,6 @@ struct ProductDetailView: View {
                 currentPayment = nil
                 handlePaymentResponse(response)
             }
-            .ignoresSafeArea()
         }
         .fullScreenCover(item: Binding(
             get: { selectedVideoURL.map { VideoURLWrapper(url: $0) } },

--- a/Moda/Feature/Setting/SettingView.swift
+++ b/Moda/Feature/Setting/SettingView.swift
@@ -134,6 +134,7 @@ struct SettingView: View {
                 title: "거래 내역",
                 subtitle: "나의 거래 기록"
             ) {
+                navigator.push(.transactions)
             }
 
             ActionCard(

--- a/Moda/Feature/Setting/Transactions/TransactionsIntent.swift
+++ b/Moda/Feature/Setting/Transactions/TransactionsIntent.swift
@@ -1,0 +1,15 @@
+//
+//  TransactionsIntent.swift
+//  Moda
+//
+//  Created by Suji Jang on 11/27/25.
+//
+
+import Foundation
+
+enum TransactionsIntent {
+    case onAppear
+    case loadMore
+    case refresh
+    case transactionTapped(String) // postId
+}

--- a/Moda/Feature/Setting/Transactions/TransactionsState.swift
+++ b/Moda/Feature/Setting/Transactions/TransactionsState.swift
@@ -1,0 +1,48 @@
+//
+//  TransactionsState.swift
+//  Moda
+//
+//  Created by Suji Jang on 11/27/25.
+//
+
+import Foundation
+
+struct TransactionsState {
+    var transactions: [Transaction] = []
+    var nextCursor: String = ""
+    var hasMore: Bool = true
+
+    var isLoading: Bool = false
+    var errorMessage: String? = nil
+}
+
+struct Transaction: Identifiable {
+    let id: String
+    let productName: String
+    let price: Int
+    let paidAt: String
+    let postId: String
+    let merchantUid: String
+    let thumbnailURL: String?
+
+    var formattedPrice: String {
+        "\(price.formatted())원"
+    }
+
+    var formattedDate: String {
+        // ISO 8601 날짜 포맷 파싱
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        guard let date = isoFormatter.date(from: paidAt) else {
+            return paidAt
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd HH:mm"
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+
+        return formatter.string(from: date)
+    }
+}

--- a/Moda/Feature/Setting/Transactions/TransactionsStore.swift
+++ b/Moda/Feature/Setting/Transactions/TransactionsStore.swift
@@ -41,34 +41,67 @@ final class TransactionsStore {
         if refresh {
             state.nextCursor = ""
             state.hasMore = true
+            state.errorMessage = nil
         }
 
         state.isLoading = true
         Task {
             do {
+                print("📦 거래 내역 로드 시작 (refresh: \(refresh))")
                 let cursor = refresh ? nil : (state.nextCursor.isEmpty ? nil : state.nextCursor)
                 let response = try await postAPI.getPaymentList(
                     next: cursor,
                     limit: "20"
                 )
 
-                let newTransactions = response.data.map { dto -> Transaction in
-                    let thumbnailURL: String? = {
-                        guard let post = dto.post, let firstFile = post.files.first else {
-                            return nil
-                        }
-                        return NetworkConfig.baseURL + "/v1" + firstFile
-                    }()
+                print("✅ API 응답 성공 - 데이터 개수: \(response.data.count), nextCursor: \(response.nextCursor)")
 
-                    return Transaction(
-                        id: dto.id,
-                        productName: dto.productName,
-                        price: dto.price,
-                        paidAt: dto.paidAt,
-                        postId: dto.postId,
-                        merchantUid: dto.merchantUid,
-                        thumbnailURL: thumbnailURL
-                    )
+                // 각 post_id로 게시글 정보 조회하여 썸네일 가져오기
+                let newTransactions = await withTaskGroup(of: (String, Transaction?).self) { group in
+                    for dto in response.data {
+                        group.addTask {
+                            do {
+                                let post = try await self.postAPI.getPost(postId: dto.postId)
+                                let thumbnailURL = post.files.first.map { NetworkConfig.baseURL + "/v1" + $0 }
+
+                                let transaction = Transaction(
+                                    id: dto.id,
+                                    productName: dto.productName,
+                                    price: dto.price,
+                                    paidAt: dto.paidAt,
+                                    postId: dto.postId,
+                                    merchantUid: dto.merchantUid,
+                                    thumbnailURL: thumbnailURL
+                                )
+                                return (dto.id, transaction)
+                            } catch {
+                                print("⚠️ 게시글 조회 실패 (postId: \(dto.postId)): \(error)")
+                                // 게시글 조회 실패해도 거래 내역은 표시 (썸네일만 없음)
+                                let transaction = Transaction(
+                                    id: dto.id,
+                                    productName: dto.productName,
+                                    price: dto.price,
+                                    paidAt: dto.paidAt,
+                                    postId: dto.postId,
+                                    merchantUid: dto.merchantUid,
+                                    thumbnailURL: nil
+                                )
+                                return (dto.id, transaction)
+                            }
+                        }
+                    }
+
+                    var results: [String: Transaction] = [:]
+                    for await (id, transaction) in group {
+                        if let transaction = transaction {
+                            results[id] = transaction
+                        }
+                    }
+
+                    // 원본 순서 유지
+                    return response.data.compactMap { dto in
+                        results[dto.id]
+                    }
                 }
 
                 if refresh {
@@ -81,9 +114,13 @@ final class TransactionsStore {
 
                 state.nextCursor = response.nextCursor
                 state.hasMore = !response.nextCursor.isEmpty && response.nextCursor != "0"
+                print("✅ 거래 내역 로드 완료 - 총 \(state.transactions.count)개")
             } catch {
                 state.errorMessage = error.localizedDescription
-                print("거래 내역 로드 실패: \(error)")
+                print("❌ 거래 내역 로드 실패: \(error)")
+                if let networkError = error as? NetworkError {
+                    print("❌ NetworkError: \(networkError)")
+                }
             }
             state.isLoading = false
         }

--- a/Moda/Feature/Setting/Transactions/TransactionsStore.swift
+++ b/Moda/Feature/Setting/Transactions/TransactionsStore.swift
@@ -1,0 +1,91 @@
+//
+//  TransactionsStore.swift
+//  Moda
+//
+//  Created by Suji Jang on 11/27/25.
+//
+
+import SwiftUI
+
+@MainActor
+@Observable
+final class TransactionsStore {
+    var state = TransactionsState()
+
+    private let postAPI: PostAPIProtocol
+
+    init(postAPI: PostAPIProtocol = PostAPI.shared) {
+        self.postAPI = postAPI
+    }
+
+    func send(_ intent: TransactionsIntent) {
+        switch intent {
+        case .onAppear:
+            if state.transactions.isEmpty {
+                loadTransactions(refresh: true)
+            }
+
+        case .loadMore:
+            guard !state.isLoading, state.hasMore else { return }
+            loadTransactions(refresh: false)
+
+        case .refresh:
+            loadTransactions(refresh: true)
+
+        case .transactionTapped:
+            break
+        }
+    }
+
+    private func loadTransactions(refresh: Bool) {
+        if refresh {
+            state.nextCursor = ""
+            state.hasMore = true
+        }
+
+        state.isLoading = true
+        Task {
+            do {
+                let cursor = refresh ? nil : (state.nextCursor.isEmpty ? nil : state.nextCursor)
+                let response = try await postAPI.getPaymentList(
+                    next: cursor,
+                    limit: "20"
+                )
+
+                let newTransactions = response.data.map { dto -> Transaction in
+                    let thumbnailURL: String? = {
+                        guard let post = dto.post, let firstFile = post.files.first else {
+                            return nil
+                        }
+                        return NetworkConfig.baseURL + "/v1" + firstFile
+                    }()
+
+                    return Transaction(
+                        id: dto.id,
+                        productName: dto.productName,
+                        price: dto.price,
+                        paidAt: dto.paidAt,
+                        postId: dto.postId,
+                        merchantUid: dto.merchantUid,
+                        thumbnailURL: thumbnailURL
+                    )
+                }
+
+                if refresh {
+                    state.transactions = newTransactions
+                } else {
+                    let existingIds = Set(state.transactions.map { $0.id })
+                    let unique = newTransactions.filter { !existingIds.contains($0.id) }
+                    state.transactions.append(contentsOf: unique)
+                }
+
+                state.nextCursor = response.nextCursor
+                state.hasMore = !response.nextCursor.isEmpty && response.nextCursor != "0"
+            } catch {
+                state.errorMessage = error.localizedDescription
+                print("거래 내역 로드 실패: \(error)")
+            }
+            state.isLoading = false
+        }
+    }
+}

--- a/Moda/Feature/Setting/Transactions/TransactionsView.swift
+++ b/Moda/Feature/Setting/Transactions/TransactionsView.swift
@@ -1,0 +1,216 @@
+//
+//  TransactionsView.swift
+//  Moda
+//
+//  Created by Suji Jang on 11/27/25.
+//
+
+import SwiftUI
+import Kingfisher
+
+struct TransactionsView: View {
+    @EnvironmentObject var navigator: AppNavigator
+    @State private var store = TransactionsStore()
+
+    var body: some View {
+        ZStack {
+            Color.white.ignoresSafeArea()
+
+            if store.state.isLoading && store.state.transactions.isEmpty {
+                shimmerList
+            } else if store.state.transactions.isEmpty {
+                emptyStateView
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(Array(store.state.transactions.enumerated()), id: \.element.id) { index, transaction in
+                            TransactionItemView(
+                                transaction: transaction,
+                                onTapped: { navigator.push(.productDetail(postId: transaction.postId)) }
+                            )
+                            .onAppear {
+                                if index >= store.state.transactions.count - 4 {
+                                    store.send(.loadMore)
+                                }
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 16)
+                    .padding(.bottom, 100)
+                }
+                .refreshable {
+                    store.send(.refresh)
+                }
+            }
+        }
+        .navigationTitle("거래 내역")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    navigator.pop()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 18))
+                        .foregroundColor(.gray1)
+                }
+            }
+        }
+        .task {
+            store.send(.onAppear)
+        }
+    }
+
+    private var shimmerList: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(0..<5, id: \.self) { _ in
+                    TransactionShimmerView()
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+        }
+    }
+
+    private var emptyStateView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "cart.badge.questionmark")
+                .font(.system(size: 48))
+                .foregroundColor(.gray3)
+
+            Text("거래 내역이 없습니다")
+                .H2()
+                .foregroundColor(.gray2)
+
+            Text("결제를 완료한 상품이 없습니다")
+                .Body2()
+                .foregroundColor(.gray3)
+        }
+    }
+}
+
+private struct TransactionItemView: View {
+    let transaction: Transaction
+    let onTapped: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            if let thumbnailURL = transaction.thumbnailURL, let url = URL(string: thumbnailURL) {
+                KFImage(url)
+                    .requestModifier(KFHeaders.modifier)
+                    .placeholder {
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(Color.gray5)
+                    }
+                    .cacheOriginalImage()
+                    .fade(duration: 0.2)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 80, height: 80)
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            } else {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color.gray5)
+                    .frame(width: 80, height: 80)
+                    .overlay {
+                        Image(systemName: "photo")
+                            .foregroundColor(.gray3)
+                    }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(transaction.productName)
+                    .Body1()
+                    .foregroundColor(.gray1)
+                    .lineLimit(2)
+
+                Text(transaction.formattedPrice)
+                    .H2()
+                    .foregroundColor(.gray1)
+
+                Spacer()
+
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(.green1)
+
+                    Text(transaction.formattedDate)
+                        .Body2()
+                        .foregroundColor(.gray2)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14))
+                .foregroundColor(.gray3)
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.gray4, lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onTapped()
+        }
+    }
+}
+
+private struct TransactionShimmerView: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.gray4)
+                .frame(width: 80, height: 80)
+                .shimmer()
+
+            VStack(alignment: .leading, spacing: 6) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.gray4)
+                    .frame(height: 16)
+                    .shimmer()
+
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.gray4)
+                    .frame(width: 100, height: 20)
+                    .shimmer()
+
+                Spacer()
+
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.gray4)
+                    .frame(width: 120, height: 12)
+                    .shimmer()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Circle()
+                .fill(Color.gray4)
+                .frame(width: 20, height: 20)
+                .shimmer()
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.gray4, lineWidth: 1)
+        )
+    }
+}
+
+#Preview {
+    TransactionsView()
+        .environmentObject(AppNavigator.shared)
+}

--- a/Moda/Feature/Setting/Transactions/TransactionsView.swift
+++ b/Moda/Feature/Setting/Transactions/TransactionsView.swift
@@ -18,6 +18,8 @@ struct TransactionsView: View {
 
             if store.state.isLoading && store.state.transactions.isEmpty {
                 shimmerList
+            } else if let errorMessage = store.state.errorMessage {
+                errorView(message: errorMessage)
             } else if store.state.transactions.isEmpty {
                 emptyStateView
             } else {
@@ -61,6 +63,10 @@ struct TransactionsView: View {
         .task {
             store.send(.onAppear)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .postPaymentCompleted)) { _ in
+            print("🔔 결제 완료 notification 수신 - 거래 내역 새로고침")
+            store.send(.refresh)
+        }
     }
 
     private var shimmerList: some View {
@@ -90,6 +96,33 @@ struct TransactionsView: View {
                 .foregroundColor(.gray3)
         }
     }
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 48))
+                .foregroundColor(.red)
+
+            Text("오류가 발생했습니다")
+                .H2()
+                .foregroundColor(.gray1)
+
+            Text(message)
+                .Body2()
+                .foregroundColor(.gray2)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            Button("다시 시도") {
+                store.send(.refresh)
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 12)
+            .background(Color.blue1)
+            .foregroundColor(.white)
+            .cornerRadius(8)
+        }
+    }
 }
 
 private struct TransactionItemView: View {
@@ -98,19 +131,16 @@ private struct TransactionItemView: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            if let thumbnailURL = transaction.thumbnailURL, let url = URL(string: thumbnailURL) {
-                KFImage(url)
-                    .requestModifier(KFHeaders.modifier)
-                    .placeholder {
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .fill(Color.gray5)
-                    }
-                    .cacheOriginalImage()
-                    .fade(duration: 0.2)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 80, height: 80)
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            if let thumbnailURL = transaction.thumbnailURL {
+                // 썸네일 URL에서 /v1 이후 경로 추출 (MediaImageView가 요구하는 형식)
+                let mediaPath = thumbnailURL.replacingOccurrences(of: NetworkConfig.baseURL + "/v1", with: "")
+
+                MediaImageView(
+                    mediaURL: mediaPath,
+                    contentMode: .fill
+                )
+                .frame(width: 80, height: 80)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             } else {
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .fill(Color.gray5)

--- a/Moda/Secret/KakaoKey.xcconfig
+++ b/Moda/Secret/KakaoKey.xcconfig
@@ -1,0 +1,11 @@
+//
+//  KaKaoKey.xcconfig
+//  Moda
+//
+//  Created by hyunMac on 11/27/25.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project
+
+KakaoKey = bc0d85c844ed10319a488b5e1005fd37


### PR DESCRIPTION
# Pull requests

## 작업한 브랜치
> 관련된 이슈 번호를 적어주세요.  
> ex - #0
- #79 

## 작업한 내용
> 이번 PR에서 수행한 주요 작업 내용을 간략히 작성해주세요.
- PG 결제 내역 API 조회
- PG 결제 웹뷰 safeArea 설정

> 
## 스크린샷
> 시각적으로 확인이 필요한 경우 첨부해주세요.

|거래 내역|
|:--:|
|<img width="300" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-11-28 at 14 36 49" src="https://github.com/user-attachments/assets/aafada6b-8a61-44b5-a107-5bf6d8aff29b" />|
